### PR TITLE
Add support for passing in custom environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ configVersion: 1
 # Environment variables to be set in the runtime environment
 env:
   CUSTOM_VAR: CUSTOM_VALUE
-  CUSTOM_PATH: '%%.CWD%%/some/path'
+  CUSTOM_PATH: '%%CWD%%/some/path'
 # JVM options to be passed to the java command
 jvmOpts:
   - '-Xmx2g'
@@ -68,10 +68,13 @@ and `<custom.xyz>` refer to the options from the two configuration files, respec
 Note that the custom `jvmOpts` appear after the static `jvmOpts` and thus typically take precendence; the exact
 behaviour may depend on the Java distribution.
 
-`env` supports a very limited set of automatic expansions if you surround the expansion variable with `%%` as shown above,
-for `CUSTOM_PATH`. The following expansions are supported:
+`env` block, both in static and custom configuration, supports restricted set of automatic expansions for values
+assigned to environment variables. Variables are expanded if they are surrounded with `%%` as shown above
+for `CUSTOM_PATH`. The following fixed expansions are supported:
 
-* `%%.CWD%%`: The current working directory of the user which executed this process
+* `%%CWD%%`: The current working directory of the user which executed this process
+
+Expansions are only performed on the values. No expansions are performed on the keys.
 
 # License
 This repository is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ configVersion: 1
 # Environment variables to be set in the runtime environment
 env:
   CUSTOM_VAR: CUSTOM_VALUE
-  CUSTOM_PATH: '%%CWD%%/some/path'
+  CUSTOM_PATH: '{{CWD}}/some/path'
 # JVM options to be passed to the java command
 jvmOpts:
   - '-Xmx2g'
@@ -69,10 +69,10 @@ Note that the custom `jvmOpts` appear after the static `jvmOpts` and thus typica
 behaviour may depend on the Java distribution.
 
 `env` block, both in static and custom configuration, supports restricted set of automatic expansions for values
-assigned to environment variables. Variables are expanded if they are surrounded with `%%` as shown above
+assigned to environment variables. Variables are expanded if they are surrounded with `{{` and `}}` as shown above
 for `CUSTOM_PATH`. The following fixed expansions are supported:
 
-* `%%CWD%%`: The current working directory of the user which executed this process
+* `{{CWD}}`: The current working directory of the user which executed this process
 
 Expansions are only performed on the values. No expansions are performed on the keys.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ javaHome: javaHome
 # The classpath entries; the final classpath is the ':'-concatenated list in the given order
 classpath:
   - ./foo.jar
+# Environment Variables to be set in the environment
+env:
+  CUSTOM_VAR: CUSTOM_VALUE
 # JVM options to be passed to the java command
 jvmOpts:
   - '-Xmx1g'
@@ -34,6 +37,10 @@ args:
 # CustomLauncherConfig
 configType: java
 configVersion: 1
+# Environment variables to be set in the runtime environment
+env:
+  CUSTOM_VAR: CUSTOM_VALUE
+  CUSTOM_PATH: '%%.CWD%%/some/path'
 # JVM options to be passed to the java command
 jvmOpts:
   - '-Xmx2g'
@@ -60,6 +67,11 @@ and `<custom.xyz>` refer to the options from the two configuration files, respec
 
 Note that the custom `jvmOpts` appear after the static `jvmOpts` and thus typically take precendence; the exact
 behaviour may depend on the Java distribution.
+
+`env` supports a very limited set of automatic expansions if you surround the expansion variable with `%%` as shown above,
+for `CUSTOM_PATH`. The following expansions are supported:
+
+* `%%.CWD%%`: The current working directory of the user which executed this process
 
 # License
 This repository is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -22,20 +22,22 @@ import (
 )
 
 type StaticLauncherConfig struct {
-	ConfigType    string `yaml:"configType"`
-	ConfigVersion int    `yaml:"configVersion"`
-	ServiceName   string `yaml:"serviceName"`
-	MainClass     string `yaml:"mainClass"`
-	JavaHome      string `yaml:"javaHome"`
+	ConfigType    string            `yaml:"configType"`
+	ConfigVersion int               `yaml:"configVersion"`
+	ServiceName   string            `yaml:"serviceName"`
+	MainClass     string            `yaml:"mainClass"`
+	JavaHome      string            `yaml:"javaHome"`
+	Env           map[string]string `yaml:"env"`
 	Classpath     []string
 	JvmOpts       []string `yaml:"jvmOpts"`
 	Args          []string
 }
 
 type CustomLauncherConfig struct {
-	ConfigType    string   `yaml:"configType"`
-	ConfigVersion int      `yaml:"configVersion"`
-	JvmOpts       []string `yaml:"jvmOpts"`
+	ConfigType    string            `yaml:"configType"`
+	ConfigVersion int               `yaml:"configVersion"`
+	JvmOpts       []string          `yaml:"jvmOpts"`
+	Env           map[string]string `yaml:"env"`
 }
 
 func ParseStaticConfig(yamlString []byte) StaticLauncherConfig {

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -112,7 +112,7 @@ func TestParseCustomConfigWithEnvPlaceholder(t *testing.T) {
 configType: java
 configVersion: 1
 env:
-  SOME_ENV_VAR: '%%.CWD%%/etc/profile'
+  SOME_ENV_VAR: '{{CWD}}/etc/profile'
 jvmOpts:
   - jvmOpt1
   - jvmOpt2
@@ -122,7 +122,7 @@ jvmOpts:
 		ConfigType:    "java",
 		ConfigVersion: 1,
 		Env: map[string]string{
-			"SOME_ENV_VAR": "%%.CWD%%/etc/profile",
+			"SOME_ENV_VAR": "{{CWD}}/etc/profile",
 		},
 		JvmOpts: []string{"jvmOpt1", "jvmOpt2"}}
 

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	TemplateDelims = "%%"
+	TemplateDelimsOpen  = "{{"
+	TemplateDelimsClose = "}}"
 )
 
 type processExecutor interface {
@@ -138,5 +139,5 @@ func createReplacer() *strings.Replacer {
 }
 
 func delim(str string) string {
-	return fmt.Sprintf("%s%s%s", TemplateDelims, str, TemplateDelims)
+	return fmt.Sprintf("%s%s%s", TemplateDelimsOpen, str, TemplateDelimsClose)
 }

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -48,7 +48,7 @@ func TestGetJavaHome(t *testing.T) {
 func TestSetCustomEnvironment(t *testing.T) {
 	originalEnv := make(map[string]string)
 	customEnv := map[string]string{
-		"SOME_PATH": "%%.CWD%%/full/path",
+		"SOME_PATH": "%%CWD%%/full/path",
 		"SOME_VAR":  "CUSTOM_VAR",
 	}
 
@@ -96,7 +96,40 @@ func TestSetCustomEnvironment(t *testing.T) {
 	if !reflect.DeepEqual(m.env, expectedEnv) {
 		t.Errorf("Expected custom environment to be %v, but instead was %v", expectedEnv, m.env)
 	}
+}
 
+func TestUnknownVariablesAreNotExpanded(t *testing.T) {
+	originalEnv := make(map[string]string)
+	customEnv := map[string]string{
+		"SOME_VAR": "%%FOO%%",
+	}
+
+	fillEnvironmentVariables(originalEnv, customEnv)
+
+	if val, ok := originalEnv["SOME_VAR"]; ok {
+		if val != "%%FOO%%" {
+			t.Errorf("For SOME_VAR, expected %s, but got %s", "%%FOO%%", val)
+		}
+	} else {
+		t.Errorf("Expected SOME_VAR to exist in map, but it didn't")
+	}
+}
+
+func TestKeysAreNotExpanded(t *testing.T) {
+	originalEnv := make(map[string]string)
+	customEnv := map[string]string{
+		"%%CWD%%": "Value",
+	}
+
+	fillEnvironmentVariables(originalEnv, customEnv)
+
+	if val, ok := originalEnv["%%CWD%%"]; ok {
+		if val != "Value" {
+			t.Errorf("For %%CWD%%, expected %s, but got %s", "Value", val)
+		}
+	} else {
+		t.Errorf("Expected %%CWD%% to exist in map and not be expanded, but it didn't")
+	}
 }
 
 func (m *mockProcessExecutor) Exec(command string, args []string, env []string) error {

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -52,11 +52,11 @@ func TestSetCustomEnvironment(t *testing.T) {
 		"SOME_VAR":  "CUSTOM_VAR",
 	}
 
-	fillEnvironmentVariables(originalEnv, customEnv)
+	env := replaceEnvironmentVariables(merge(originalEnv, customEnv))
 
 	cwd := getWorkingDir()
 
-	if val, ok := originalEnv["SOME_PATH"]; ok {
+	if val, ok := env["SOME_PATH"]; ok {
 		expected := fmt.Sprintf("%s/full/path", cwd)
 		if val != expected {
 			t.Errorf("For SOME_PATH, expected %s, but got %s", expected, val)
@@ -65,7 +65,7 @@ func TestSetCustomEnvironment(t *testing.T) {
 		t.Errorf("Expected SOME_PATH to exist in map but it didn't")
 	}
 
-	if val, ok := originalEnv["SOME_VAR"]; ok {
+	if val, ok := env["SOME_VAR"]; ok {
 		if val != "CUSTOM_VAR" {
 			t.Errorf("For SOME_VAR, expected %s, but got %s", "CUSTOM_VAR", val)
 		}
@@ -75,7 +75,7 @@ func TestSetCustomEnvironment(t *testing.T) {
 
 	m := mockProcessExecutor{}
 	args := []string{"arg1", "arg2"}
-	execWithChecks("my-command", args, originalEnv, &m)
+	execWithChecks("my-command", args, env, &m)
 
 	if m.command != "my-command" {
 		t.Errorf("Expected command to be run was %s, but instead was %s", "my-command", m.command)
@@ -104,9 +104,9 @@ func TestUnknownVariablesAreNotExpanded(t *testing.T) {
 		"SOME_VAR": "{{FOO}}",
 	}
 
-	fillEnvironmentVariables(originalEnv, customEnv)
+	env := replaceEnvironmentVariables(merge(originalEnv, customEnv))
 
-	if val, ok := originalEnv["SOME_VAR"]; ok {
+	if val, ok := env["SOME_VAR"]; ok {
 		if val != "{{FOO}}" {
 			t.Errorf("For SOME_VAR, expected %s, but got %s", "{{FOO}}", val)
 		}
@@ -121,9 +121,9 @@ func TestKeysAreNotExpanded(t *testing.T) {
 		"{{CWD}}": "Value",
 	}
 
-	fillEnvironmentVariables(originalEnv, customEnv)
+	env := replaceEnvironmentVariables(merge(originalEnv, customEnv))
 
-	if val, ok := originalEnv["{{CWD}}"]; ok {
+	if val, ok := env["{{CWD}}"]; ok {
 		if val != "Value" {
 			t.Errorf("For %%CWD%%, expected %s, but got %s", "Value", val)
 		}

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -16,9 +16,18 @@
 package launchlib
 
 import (
+	"fmt"
 	"os"
+	"reflect"
+	"sort"
 	"testing"
 )
+
+type mockProcessExecutor struct {
+	command string
+	args    []string
+	env     []string
+}
 
 func TestGetJavaHome(t *testing.T) {
 	originalJavaHome := os.Getenv("JAVA_HOME")
@@ -34,6 +43,68 @@ func TestGetJavaHome(t *testing.T) {
 	}
 
 	setEnvOrFail("JAVA_HOME", originalJavaHome)
+}
+
+func TestSetCustomEnvironment(t *testing.T) {
+	originalEnv := make(map[string]string)
+	customEnv := map[string]string{
+		"SOME_PATH": "%%.CWD%%/full/path",
+		"SOME_VAR":  "CUSTOM_VAR",
+	}
+
+	fillEnvironmentVariables(originalEnv, customEnv)
+
+	cwd := getWorkingDir()
+
+	if val, ok := originalEnv["SOME_PATH"]; ok {
+		expected := fmt.Sprintf("%s/full/path", cwd)
+		if val != expected {
+			t.Errorf("For SOME_PATH, expected %s, but got %s", expected, val)
+		}
+	} else {
+		t.Errorf("Expected SOME_PATH to exist in map but it didn't")
+	}
+
+	if val, ok := originalEnv["SOME_VAR"]; ok {
+		if val != "CUSTOM_VAR" {
+			t.Errorf("For SOME_VAR, expected %s, but got %s", "CUSTOM_VAR", val)
+		}
+	} else {
+		t.Errorf("Expected CUSTOM_VAR to exist in map, but it didn't")
+	}
+
+	m := mockProcessExecutor{}
+	args := []string{"arg1", "arg2"}
+	execWithChecks("my-command", args, originalEnv, &m)
+
+	if m.command != "my-command" {
+		t.Errorf("Expected command to be run was %s, but instead was %s", "my-command", m.command)
+	}
+
+	if !reflect.DeepEqual(m.args, args) {
+		t.Errorf("Expected incoming args to be %v, but were %v", args, m.args)
+	}
+
+	startingEnv := os.Environ()
+	expectedEnv := append(startingEnv, []string{
+		fmt.Sprintf("SOME_PATH=%s/full/path", cwd),
+		"SOME_VAR=CUSTOM_VAR",
+	}...)
+
+	sort.Strings(m.env)
+	sort.Strings(expectedEnv)
+	if !reflect.DeepEqual(m.env, expectedEnv) {
+		t.Errorf("Expected custom environment to be %v, but instead was %v", expectedEnv, m.env)
+	}
+
+}
+
+func (m *mockProcessExecutor) Exec(command string, args []string, env []string) error {
+	m.command = command
+	m.args = args
+	m.env = env
+
+	return nil
 }
 
 func setEnvOrFail(key string, value string) {

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -48,7 +48,7 @@ func TestGetJavaHome(t *testing.T) {
 func TestSetCustomEnvironment(t *testing.T) {
 	originalEnv := make(map[string]string)
 	customEnv := map[string]string{
-		"SOME_PATH": "%%CWD%%/full/path",
+		"SOME_PATH": "{{CWD}}/full/path",
 		"SOME_VAR":  "CUSTOM_VAR",
 	}
 
@@ -101,14 +101,14 @@ func TestSetCustomEnvironment(t *testing.T) {
 func TestUnknownVariablesAreNotExpanded(t *testing.T) {
 	originalEnv := make(map[string]string)
 	customEnv := map[string]string{
-		"SOME_VAR": "%%FOO%%",
+		"SOME_VAR": "{{FOO}}",
 	}
 
 	fillEnvironmentVariables(originalEnv, customEnv)
 
 	if val, ok := originalEnv["SOME_VAR"]; ok {
-		if val != "%%FOO%%" {
-			t.Errorf("For SOME_VAR, expected %s, but got %s", "%%FOO%%", val)
+		if val != "{{FOO}}" {
+			t.Errorf("For SOME_VAR, expected %s, but got %s", "{{FOO}}", val)
 		}
 	} else {
 		t.Errorf("Expected SOME_VAR to exist in map, but it didn't")
@@ -118,12 +118,12 @@ func TestUnknownVariablesAreNotExpanded(t *testing.T) {
 func TestKeysAreNotExpanded(t *testing.T) {
 	originalEnv := make(map[string]string)
 	customEnv := map[string]string{
-		"%%CWD%%": "Value",
+		"{{CWD}}": "Value",
 	}
 
 	fillEnvironmentVariables(originalEnv, customEnv)
 
-	if val, ok := originalEnv["%%CWD%%"]; ok {
+	if val, ok := originalEnv["{{CWD}}"]; ok {
 		if val != "Value" {
 			t.Errorf("For %%CWD%%, expected %s, but got %s", "Value", val)
 		}


### PR DESCRIPTION
Includes extremely limited support for some very limited
template expansion, currently limited to just expanding
the current working directory of the process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/go-java-launcher/9)

<!-- Reviewable:end -->
