### PR TITLE
added executable path substitution and fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ args:
 ```yaml
 # StaticLauncherConfig - executable version
 # REQUIRED - The type of configuration, must be the string "executable"
-configType: java
+configType: executable
 # REQUIRED - The version of the configuration format, must be the integer 1
 configVersion: 1
 # OPTIONAL - Environment Variables to be set in the environment (Note: cannot be referenced on args list)

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -27,7 +27,7 @@ const (
 	TemplateDelimsOpen  = "{{"
 	TemplateDelimsClose = "}}"
 	// ExecPathBlackListRegex matches characters disallowed in paths we allow to be passed to exec()
-	ExecPathBlackListRegex = `[^\w.\/_\-]`
+	ExecPathBlackListRegex = `[^\w.\/_\-~]`
 )
 
 func LaunchWithConfig(staticConfigFile, customConfigFile string) error {
@@ -132,7 +132,8 @@ func Launch(staticConfig *StaticLauncherConfig, customConfig *CustomLauncherConf
 		args = append(args, "-classpath", classpath)
 		args = append(args, staticConfig.JavaConfig.MainClass)
 	} else if staticConfig.ConfigType == "executable" {
-		executable, executableErr = verifyPathIsSafeForExec(staticConfig.Executable)
+		replacer := createReplacer()
+		executable, executableErr = verifyPathIsSafeForExec(replacer.Replace(staticConfig.Executable))
 		if executableErr != nil {
 			return executableErr
 		}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/go-java-launcher/24)
<!-- Reviewable:end -->
