### PR TITLE
Allow additional classpath args in custom configs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dirs:
 ```yaml
 # StaticLauncherConfig - executable version
 # REQUIRED - The type of configuration, must be the string "executable"
-configType: java
+configType: executable
 # REQUIRED - The version of the configuration format, must be the integer 1
 configVersion: 1
 # OPTIONAL - Environment Variables to be set in the environment (Note: cannot be referenced on args list)
@@ -70,6 +70,10 @@ env:
 # Additional JVM options to be passed to the java command, will override defaults in static config. Ignored if configType is "executable"
 jvmOpts:
   - '-Xmx2g'
+# Additional classpath entries to be appended to the existing classpath list in the static config.
+# Append only. Unlike the static config, this must be an absolute path to the resource.
+classpath
+  - /path/to/additional/resource
 ```
 
 The launcher is invoked as:

--- a/integration_test/init_integration_test.go
+++ b/integration_test/init_integration_test.go
@@ -36,8 +36,8 @@ func TestInitStatus(t *testing.T) {
 	// No valid pidfile
 	stdout, stderr, exitCode := runInit("status", "--pidFile", "bogus-file")
 	assert.Empty(t, stdout)
-	assert.Equal(t, stderr, "Failed to determine whether process is running for pid-file: bogus-file. Exit code: 3. "+
-		"Underlying error: open bogus-file: no such file or directory")
+	assert.Equal(t, "Failed to determine whether process is running for pid-file: bogus-file. Exit code: 3. "+
+		"Underlying error: open bogus-file: no such file or directory", stderr)
 	assert.Equal(t, 3, exitCode)
 
 	// Valid pidfile, but corresponding process doesn't exist

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -34,6 +34,16 @@ func TestMainMethod(t *testing.T) {
 	assert.Regexp(t, `\nmain method\n`, string(output))
 }
 
+func TestMainMethodWithClasspath(t *testing.T) {
+	output, err := runMainWithArgs(t, "test_resources/launcher-static.yml", "test_resources/launcher-custom-classpath.yml")
+	require.NoError(t, err, "failed: %s", output)
+
+	// part of expected output from launcher
+	assert.Regexp(t, `Argument list to executable binary: \[.+/bin/java -Xmx4M -classpath .+/github.com/palantir/go-java-launcher/integration_test/test_resources:/home/palantir/github.com/palantir/classpath Main arg1\]`, output)
+	// expected output of Java program
+	assert.Regexp(t, `\nmain method\n`, string(output))
+}
+
 func TestPanicsWhenJavaHomeIsNotAFile(t *testing.T) {
 	_, err := runMainWithArgs(t, "test_resources/launcher-static-bad-java-home.yml", "foo")
 	require.Error(t, err, "error: Failed to determine is path is safe to execute: /foo/bar/bin/java")

--- a/integration_test/test_resources/launcher-custom-classpath.yml
+++ b/integration_test/test_resources/launcher-custom-classpath.yml
@@ -1,0 +1,4 @@
+configType: java
+configVersion: 1
+classpath:
+  - /home/palantir/github.com/palantir/classpath

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -48,6 +48,7 @@ type CustomLauncherConfig struct {
 	LauncherConfig `yaml:",inline"`
 	JvmOpts        []string          `yaml:"jvmOpts"`
 	Env            map[string]string `yaml:"env"`
+	Classpath      []string          `yaml:"classpath"`
 }
 
 type LauncherConfig struct {

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -114,6 +114,9 @@ env:
 jvmOpts:
   - jvmOpt1
   - jvmOpt2
+classpath:
+  - classpath1
+  - classpath2
 `,
 			want: CustomLauncherConfig{
 				LauncherConfig: LauncherConfig{
@@ -124,11 +127,12 @@ jvmOpts:
 					"SOME_ENV_VAR":  "/etc/profile",
 					"OTHER_ENV_VAR": "/etc/redhat-release",
 				},
-				JvmOpts: []string{"jvmOpt1", "jvmOpt2"},
+				JvmOpts:   []string{"jvmOpt1", "jvmOpt2"},
+				Classpath: []string{"classpath1", "classpath2"},
 			},
 		},
 		{
-			name: "java custom config without env",
+			name: "java custom config with jvmOpts",
 			data: `
 configType: java
 configVersion: 1
@@ -142,6 +146,23 @@ jvmOpts:
 					ConfigVersion: 1,
 				},
 				JvmOpts: []string{"jvmOpt1", "jvmOpt2"},
+			},
+		},
+		{
+			name: "java custom config with classpath",
+			data: `
+configType: java
+configVersion: 1
+classpath:
+  - classpath1
+  - classpath2
+`,
+			want: CustomLauncherConfig{
+				LauncherConfig: LauncherConfig{
+					ConfigType:    "java",
+					ConfigVersion: 1,
+				},
+				Classpath: []string{"classpath1", "classpath2"},
 			},
 		},
 		{

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -61,7 +61,9 @@ func CompileCmdFromConfig(staticConfig *StaticLauncherConfig, customConfig *Cust
 		}
 		fmt.Println("Using JAVA_HOME:", javaHome)
 
-		classpath := joinClasspathEntries(absolutizeClasspathEntries(workingDir, staticConfig.JavaConfig.Classpath))
+		staticEntries := absolutizeClasspathEntries(workingDir, staticConfig.JavaConfig.Classpath)
+		customEntries := customConfig.Classpath
+		classpath := joinClasspathEntries(append(staticEntries, customEntries...))
 		fmt.Println("Classpath:", classpath)
 
 		executable, executableErr = verifyPathIsSafeForExec(path.Join(javaHome, "/bin/java"))


### PR DESCRIPTION
This allows users to add adtional classpath args in the custom config
file in the same vein as adding additional jvmOpts.