### PR TITLE
Allow for definition and launch of process groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ args:
 dirs:
   - var/data/tmp
   - var/log
-# OPTIONAL - A map of configurations of sub-processes to launch
-sub-processes:
+# OPTIONAL - A map of configurations of subProcesses to launch
+subProcesses:
   SUB_PROCESS_NAME:
-    # another StaticLauncherConfig, cannot have it's own sub-processes
+    # another StaticLauncherConfig, cannot have it's own subProcesses
     configType: executable
     configVersion: 1
     env:
@@ -68,9 +68,9 @@ dirs:
   - var/data/tmp
   - var/log
 # OPTIONAL - A map of configurations of secondary processes to launch
-sub-processes:
+subProcesses:
   SUB_PROCESS_NAME:
-    # another StaticLauncherConfig, cannot have it's own sub-processes
+    # another StaticLauncherConfig, cannot have it's own subProcesses
     configType: executable
     configVersion: 1
     env:
@@ -95,9 +95,9 @@ env:
 jvmOpts:
   - '-Xmx2g'
 # OPTIONAL - A map of configurations of secondary processes to launch
-sub-process:
+subProcess:
   SUB_PROCESS_NAME:
-    # another CustomLauncherConfig, cannot have it's own sub-processes
+    # another CustomLauncherConfig, cannot have it's own subProcesses
     configType: executable
     configVersion: 1
     env:
@@ -126,8 +126,8 @@ and `<custom.xyz>` refer to the options from the two configuration files, respec
 Note that the custom `jvmOpts` appear after the static `jvmOpts` and thus typically take precendence; the exact
 behaviour may depend on the Java distribution.
 
-If any sub-processes are defined, they will be launched as child processes of the main process, with all of these
-processes occupying their own process group.  Additionally, a monitor sub-process will be launched, which terminates
+If any subProcesses are defined, they will be launched as child processes of the main process, with all of these
+processes occupying their own process group.  Additionally, a monitor subProcess will be launched, which terminates
 the group, should the main process die.
 
 `env` block, both in static and custom configuration, supports restricted set of automatic expansions for values

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ args:
 dirs:
   - var/data/tmp
   - var/log
+# OPTIONAL - A map of configurations of secondary processes to launch
+secondaries:
+  name:
+    StaticLauncherConfig
 ```
 
 ```yaml
@@ -55,6 +59,10 @@ args:
 dirs:
   - var/data/tmp
   - var/log
+# OPTIONAL - A map of configurations of secondary processes to launch
+secondaries:
+  name:
+    StaticLauncherConfig
 ```
 
 ```yaml
@@ -70,6 +78,10 @@ env:
 # Additional JVM options to be passed to the java command, will override defaults in static config. Ignored if configType is "executable"
 jvmOpts:
   - '-Xmx2g'
+# OPTIONAL - A map of configurations of secondary processes to launch
+secondaries:
+  name:
+    CustomLauncherConfig
 ```
 
 The launcher is invoked as:

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ dirs:
 # OPTIONAL - A map of configurations of subProcesses to launch
 subProcesses:
   SUB_PROCESS_NAME:
-    # another StaticLauncherConfig, cannot have it's own subProcesses
+    # another StaticLauncherConfig though it cannot have its own subProcesses, and uses its parent's configVersion
     configType: executable
-    configVersion: 1
     env:
       CUSTOM_VAR: CUSTOM_VALUE
     executable: "{{CWD}}/service/lib/envoy/envoy"
@@ -70,9 +69,8 @@ dirs:
 # OPTIONAL - A map of configurations of secondary processes to launch
 subProcesses:
   SUB_PROCESS_NAME:
-    # another StaticLauncherConfig, cannot have it's own subProcesses
+    # another StaticLauncherConfig though it cannot have its own subProcesses, and uses its parent's configVersion
     configType: executable
-    configVersion: 1
     env:
       CUSTOM_VAR: CUSTOM_VALUE
     executable: "{{CWD}}/service/lib/envoy/envoy"
@@ -97,9 +95,8 @@ jvmOpts:
 # OPTIONAL - A map of configurations of secondary processes to launch
 subProcess:
   SUB_PROCESS_NAME:
-    # another CustomLauncherConfig, cannot have it's own subProcesses
+    # another CustomLauncherConfig though it cannot have its own subProcesses, and uses its parent's configVersion
     configType: executable
-    configVersion: 1
     env:
       CUSTOM_VAR: CUSTOM_VALUE
 ```

--- a/init/cli/start.go
+++ b/init/cli/start.go
@@ -48,13 +48,13 @@ func start() error {
 		return cli.WithExitCode(1, errors.Wrap(err, "failed to create startup log file"))
 	}
 
-	cmd, err := launchlib.CompileCmdFromConfigFiles(lib.LauncherStaticFile, lib.LauncherCustomFile, outputFile)
+	cmd, err := launchlib.CompileCmdsFromConfigFiles(lib.LauncherStaticFile, lib.LauncherCustomFile, outputFile)
 	if err != nil {
 		return cli.WithExitCode(1,
 			errors.Wrap(err, "failed to assemble command from static and custom configuration files"))
 	}
 
-	if err := lib.StartCommand(cmd, outputFile); err != nil {
+	if err := lib.StartCommand(cmd.Primary, outputFile); err != nil {
 		return cli.WithExitCode(1, errors.Wrap(err, "failed to start process"))
 	}
 

--- a/launcher/main/main.go
+++ b/launcher/main/main.go
@@ -94,7 +94,7 @@ func main() {
 	}
 
 	for name, secondaryStatic := range staticConfig.Secondaries {
-		if err := launchlib.MkDirs(secondaryStatic.Dirs); err != nil {
+		if err := launchlib.MkDirs(secondaryStatic.Dirs, stdout); err != nil {
 			fmt.Println("Failed to create directories for secondary process ", name, err)
 			panic(err)
 		}

--- a/launcher/main/main.go
+++ b/launcher/main/main.go
@@ -42,7 +42,7 @@ func ParseMonitorArgs(args []string) (*launchlib.ProcessMonitor, error) {
 	if monitor.ServicePid, err = strconv.Atoi(args[0]); err != nil {
 		return nil, errors.Wrapf(err, "error parsing service pid")
 	}
-	if monitor.ServiceGroupId, err = strconv.Atoi(args[1]); err != nil {
+	if monitor.ServiceGroupID, err = strconv.Atoi(args[1]); err != nil {
 		return nil, errors.Wrapf(err, "error parsing service group id")
 	}
 	return monitor, nil
@@ -52,7 +52,7 @@ func GenerateMonitorArgs(monitor *launchlib.ProcessMonitor) []string {
 	return []string{
 		monitorFlag,
 		strconv.Itoa(monitor.ServicePid),
-		strconv.Itoa(monitor.ServiceGroupId),
+		strconv.Itoa(monitor.ServiceGroupID),
 	}
 }
 
@@ -109,11 +109,14 @@ func main() {
 
 	if len(cmds.Secondaries) != 0 {
 		// Ensure we are in our own process group, since the monitor kills the group
-		syscall.Setpgid(0, 0)
+		if err := syscall.Setpgid(0, 0); err != nil {
+			fmt.Printf("Unable to create process group for process including secondaries")
+			panic(err)
+		}
 
 		monitor := &launchlib.ProcessMonitor{
 			ServicePid:     os.Getpid(),
-			ServiceGroupId: syscall.Getpgrp(),
+			ServiceGroupID: syscall.Getpgrp(),
 		}
 		monitorCmd := exec.Command(os.Args[0], GenerateMonitorArgs(monitor)...)
 		monitorCmd.Stdout = os.Stdout

--- a/launcher/main/main.go
+++ b/launcher/main/main.go
@@ -39,10 +39,10 @@ func ParseMonitorArgs(args []string) (*launchlib.ProcessMonitor, error) {
 	monitor := &launchlib.ProcessMonitor{}
 
 	var err error
-	if monitor.ServicePid, err = strconv.Atoi(args[0]); err != nil {
+	if monitor.PrimaryPID, err = strconv.Atoi(args[0]); err != nil {
 		return nil, errors.Wrapf(err, "error parsing service pid")
 	}
-	if monitor.ServiceGroupID, err = strconv.Atoi(args[1]); err != nil {
+	if monitor.ProcessGroupPID, err = strconv.Atoi(args[1]); err != nil {
 		return nil, errors.Wrapf(err, "error parsing service group id")
 	}
 	return monitor, nil
@@ -51,8 +51,8 @@ func ParseMonitorArgs(args []string) (*launchlib.ProcessMonitor, error) {
 func GenerateMonitorArgs(monitor *launchlib.ProcessMonitor) []string {
 	return []string{
 		monitorFlag,
-		strconv.Itoa(monitor.ServicePid),
-		strconv.Itoa(monitor.ServiceGroupID),
+		strconv.Itoa(monitor.PrimaryPID),
+		strconv.Itoa(monitor.ProcessGroupPID),
 	}
 }
 
@@ -65,7 +65,7 @@ func main() {
 	case numArgs == 4 && os.Args[1] == monitorFlag:
 		if monitor, err := ParseMonitorArgs(os.Args[2:]); err != nil {
 			fmt.Println("error parsing monitor args", err)
-			Exit1WithMessage(fmt.Sprintf("Usage: go-java-launcher %s <service pid> <service pgid>", monitorFlag))
+			Exit1WithMessage(fmt.Sprintf("Usage: go-java-launcher %s <primary pid> <pgid>", monitorFlag))
 		} else if err = monitor.TermProcessGroupOnDeath(); err != nil {
 			fmt.Println("error running process monitor", err)
 			Exit1WithMessage("process monitor failed")
@@ -115,8 +115,8 @@ func main() {
 		}
 
 		monitor := &launchlib.ProcessMonitor{
-			ServicePid:     os.Getpid(),
-			ServiceGroupID: syscall.Getpgrp(),
+			PrimaryPID:      os.Getpid(),
+			ProcessGroupPID: syscall.Getpgrp(),
 		}
 		monitorCmd := exec.Command(os.Args[0], GenerateMonitorArgs(monitor)...)
 		monitorCmd.Stdout = os.Stdout

--- a/launcher/main/main.go
+++ b/launcher/main/main.go
@@ -147,7 +147,7 @@ func main() {
 				if os.IsNotExist(execErr) {
 					fmt.Printf("Executable not found for subProcess %s at: %s\n", name, subProcess.Path)
 				}
-				panic(err)
+				panic(execErr)
 			} else {
 				fmt.Printf("Started subProcess %s under process pid %d\n", name, subProcess.Process.Pid)
 			}

--- a/launcher/main/main.go
+++ b/launcher/main/main.go
@@ -81,14 +81,9 @@ func main() {
 	}
 
 	// Read configuration
-	staticConfig, err := launchlib.GetStaticConfigFromFile(staticConfigFile)
+	staticConfig, customConfig, err := launchlib.GetConfigsFromFiles(staticConfigFile, customConfigFile, stdout)
 	if err != nil {
-		fmt.Fprintln(stdout, "Failed to read static config file", err)
-		panic(err)
-	}
-	customConfig, err := launchlib.GetCustomConfigFromFile(customConfigFile, staticConfig, stdout)
-	if err != nil {
-		fmt.Fprintln(stdout, "Failed to read custom config file", err)
+		fmt.Println("Failed to read config files", err)
 		panic(err)
 	}
 
@@ -144,7 +139,7 @@ func main() {
 				}
 				panic(err)
 			} else {
-				fmt.Printf("Started secondary %s under process pid %s", name, secondary.Process.Pid)
+				fmt.Printf("Started secondary %s under process pid %d", name, secondary.Process.Pid)
 			}
 		}
 	}

--- a/launcher/main/main.go
+++ b/launcher/main/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	for name, subProcStatic := range staticConfig.SubProcesses {
 		if err := launchlib.MkDirs(subProcStatic.Dirs, stdout); err != nil {
-			fmt.Println("Failed to create directories for subprocess ", name, err)
+			fmt.Println("Failed to create directories for subProcess ", name, err)
 			panic(err)
 		}
 	}
@@ -111,7 +111,7 @@ func main() {
 		// For this process (referenced as 0), set the process group id to our pid (also referenced as 0), to ensure
 		// we are in our own group.
 		if err := syscall.Setpgid(0, 0); err != nil {
-			fmt.Printf("Unable to create process group for primary with subprocesses")
+			fmt.Printf("Unable to create process group for primary with subProcesses")
 			panic(err)
 		}
 
@@ -137,12 +137,12 @@ func main() {
 			if subProcess.SysProcAttr == nil {
 				subProcess.SysProcAttr = &syscall.SysProcAttr{}
 			}
-			// Do not set the pgid of the subprocesses, leaving them in the same process group as this process
+			// Do not set the pgid of the subProcesses, leaving them in the same process group as this process
 			subProcess.SysProcAttr.Setpgid = false
 			subProcess.Stdout = os.Stdout
 			subProcess.Stderr = os.Stderr
 
-			fmt.Println("Starting sub-processes ", name, subProcess.Path)
+			fmt.Println("Starting subProcesses ", name, subProcess.Path)
 			if execErr := subProcess.Start(); execErr != nil {
 				if os.IsNotExist(execErr) {
 					fmt.Printf("Executable not found for subProcess %s at: %s\n", name, subProcess.Path)

--- a/launcher/main/main.go
+++ b/launcher/main/main.go
@@ -17,14 +17,43 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"syscall"
 
+	"github.com/pkg/errors"
+
 	"github.com/palantir/go-java-launcher/launchlib"
+)
+
+const (
+	monitorFlag = "--group-monitor"
 )
 
 func Exit1WithMessage(message string) {
 	fmt.Fprintln(os.Stderr, message)
 	os.Exit(1)
+}
+
+func ParseMonitorArgs(args []string) (*launchlib.ProcessMonitor, error) {
+	monitor := &launchlib.ProcessMonitor{}
+
+	var err error
+	if monitor.ServicePid, err = strconv.Atoi(args[0]); err != nil {
+		return nil, errors.Wrapf(err, "error parsing service pid")
+	}
+	if monitor.ServiceGroupId, err = strconv.Atoi(args[1]); err != nil {
+		return nil, errors.Wrapf(err, "error parsing service group id")
+	}
+	return monitor, nil
+}
+
+func GenerateMonitorArgs(monitor *launchlib.ProcessMonitor) []string {
+	return []string{
+		monitorFlag,
+		strconv.Itoa(monitor.ServicePid),
+		strconv.Itoa(monitor.ServiceGroupId),
+	}
 }
 
 func main() {
@@ -33,8 +62,17 @@ func main() {
 	stdout := os.Stdout
 
 	switch numArgs := len(os.Args); {
+	case numArgs == 4 && os.Args[1] == monitorFlag:
+		if monitor, err := ParseMonitorArgs(os.Args[2:]); err != nil {
+			fmt.Println("error parsing monitor args", err)
+			Exit1WithMessage(fmt.Sprintf("Usage: go-java-launcher %s <service pid> <service pgid>", monitorFlag))
+		} else if err = monitor.TermProcessGroupOnDeath(); err != nil {
+			fmt.Println("error running process monitor", err)
+			Exit1WithMessage("process monitor failed")
+		}
+		return
 	case numArgs > 3:
-		Exit1WithMessage("Usage: go-java-launcher <path to StaticLauncherConfig> [<path to CustomLauncherConfig>]")
+		Exit1WithMessage("Usage: go-java-launcher <path to PrimaryStaticLauncherConfig> [<path to PrimaryCustomLauncherConfig>]")
 	case numArgs == 2:
 		staticConfigFile = os.Args[1]
 	case numArgs == 3:
@@ -48,7 +86,7 @@ func main() {
 		fmt.Fprintln(stdout, "Failed to read static config file", err)
 		panic(err)
 	}
-	customConfig, err := launchlib.GetCustomConfigFromFile(customConfigFile, stdout)
+	customConfig, err := launchlib.GetCustomConfigFromFile(customConfigFile, staticConfig, stdout)
 	if err != nil {
 		fmt.Fprintln(stdout, "Failed to read custom config file", err)
 		panic(err)
@@ -60,18 +98,61 @@ func main() {
 		panic(err)
 	}
 
+	for name, secondaryStatic := range staticConfig.Secondaries {
+		if err := launchlib.MkDirs(secondaryStatic.Dirs); err != nil {
+			fmt.Println("Failed to create directories for secondary process ", name, err)
+			panic(err)
+		}
+	}
+
 	// Compile command
-	cmd, err := launchlib.CompileCmdFromConfig(&staticConfig, &customConfig, stdout)
+	cmds, err := launchlib.CompileCmdsFromConfig(&staticConfig, &customConfig, stdout)
 	if err != nil {
-		fmt.Println("Failed to assemble executable metadata", cmd, err)
+		fmt.Println("Failed to assemble executable metadata", cmds, err)
 		panic(err)
 	}
 
-	// Execute command
-	execErr := syscall.Exec(cmd.Path, cmd.Args, cmd.Env)
+	if len(cmds.Secondaries) != 0 {
+		// Ensure we are in our own process group, since the monitor kills the group
+		syscall.Setpgid(0, 0)
+
+		monitor := &launchlib.ProcessMonitor{
+			ServicePid:     os.Getpid(),
+			ServiceGroupId: syscall.Getpgrp(),
+		}
+		monitorCmd := exec.Command(os.Args[0], GenerateMonitorArgs(monitor)...)
+		monitorCmd.Stdout = os.Stdout
+		monitorCmd.Stderr = os.Stderr
+
+		// From this point, if the launcher, or subsequent primary process dies, the process group will be terminated
+		// by the process monitor
+		if err := monitorCmd.Start(); err != nil {
+			fmt.Println("Failed to start process monitor for service process group")
+			panic(err)
+		}
+
+		for name, secondary := range cmds.Secondaries {
+			// Ensure child processes are in the same parent group
+			if secondary.SysProcAttr == nil {
+				secondary.SysProcAttr = &syscall.SysProcAttr{}
+			}
+			secondary.SysProcAttr.Setpgid = false
+
+			if execErr := secondary.Start(); execErr != nil {
+				if os.IsNotExist(execErr) {
+					fmt.Printf("Executable not found for secondary %s at: %s\n", name, secondary.Path)
+				}
+				panic(err)
+			} else {
+				fmt.Printf("Started secondary %s under process pid %s", name, secondary.Process.Pid)
+			}
+		}
+	}
+
+	execErr := syscall.Exec(cmds.Primary.Path, cmds.Primary.Args, cmds.Primary.Env)
 	if execErr != nil {
 		if os.IsNotExist(execErr) {
-			fmt.Println("Executable not found at:", cmd.Path)
+			fmt.Println("Executable not found at:", cmds.Primary.Path)
 		}
 		panic(execErr)
 	}

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -55,7 +55,7 @@ type StaticLauncherConfig struct {
 type PrimaryStaticLauncherConfig struct {
 	VersionedConfig      `yaml:",inline"`
 	StaticLauncherConfig `yaml:",inline"`
-	SubProcesses         map[string]StaticLauncherConfig `yaml:"sub-processes"`
+	SubProcesses         map[string]StaticLauncherConfig `yaml:"subProcesses"`
 }
 
 type CustomLauncherConfig struct {
@@ -67,7 +67,7 @@ type CustomLauncherConfig struct {
 type PrimaryCustomLauncherConfig struct {
 	VersionedConfig      `yaml:",inline"`
 	CustomLauncherConfig `yaml:",inline"`
-	SubProcesses         map[string]CustomLauncherConfig `yaml:"sub-processes"`
+	SubProcesses         map[string]CustomLauncherConfig `yaml:"subProcesses"`
 }
 
 type AllowedLauncherConfigValues struct {
@@ -98,7 +98,7 @@ func GetConfigsFromFiles(staticConfigFile string, customConfigFile string, stdou
 
 func validateSubProcessLimit(numberSubProcesses int) error {
 	if numberSubProcesses > 1 {
-		return errors.New("only one named sub-processes is currently allowed")
+		return errors.New("only one named subProcesses is currently allowed")
 	}
 	return nil
 }
@@ -125,7 +125,7 @@ func parseStaticConfig(yamlString []byte) (PrimaryStaticLauncherConfig, error) {
 	for name, subProcess := range config.SubProcesses {
 		if err := validateStaticConfig(&subProcess); err != nil {
 			return PrimaryStaticLauncherConfig{}, errors.Wrapf(err,
-				"failed to validate sub-process launcher configuration '%s'", name)
+				"failed to validate subProcess launcher configuration '%s'", name)
 		}
 	}
 	return config, nil
@@ -160,14 +160,14 @@ func verifyStaticWithCustomConfig(staticConfig PrimaryStaticLauncherConfig, cust
 	for name := range customConfig.SubProcesses {
 		if _, ok := staticConfig.SubProcesses[name]; !ok {
 			return errors.Errorf(
-				"custom sub-process config '%s' does not exist in the static config file", name)
+				"custom subProcess config '%s' does not exist in the static config file", name)
 		}
 	}
 
 	for name := range staticConfig.SubProcesses {
 		if _, ok := customConfig.SubProcesses[name]; !ok {
 			return errors.Errorf(
-				"no custom config exists for sub-process '%s' defined in the static config file", name)
+				"no custom config exists for subProcess '%s' defined in the static config file", name)
 		}
 	}
 	return nil

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -77,13 +77,13 @@ var allowedLauncherConfigs = AllowedLauncherConfigValues{
 	Executables:    map[string]struct{}{"java": {}, "postgres": {}, "influxd": {}, "grafana-server": {}, "envoy": {}},
 }
 
-func GetConfigsFromFiles(staticConfigFile string, customConfigFile string) (PrimaryStaticLauncherConfig, PrimaryCustomLauncherConfig, error) {
+func GetConfigsFromFiles(staticConfigFile string, customConfigFile string, stdout io.Writer) (PrimaryStaticLauncherConfig, PrimaryCustomLauncherConfig, error) {
 	staticConfig, err := getStaticConfigFromFile(staticConfigFile)
 	if err != nil {
 		return PrimaryStaticLauncherConfig{}, PrimaryCustomLauncherConfig{}, err
 	}
 
-	customConfig, err := getCustomConfigFromFile(customConfigFile)
+	customConfig, err := getCustomConfigFromFile(customConfigFile, stdout)
 	if err != nil {
 		return PrimaryStaticLauncherConfig{}, PrimaryCustomLauncherConfig{}, err
 	}

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -123,10 +123,7 @@ func validateStaticConfig(config *StaticLauncherConfig) error {
 		}
 	}
 
-	if err := validateExecutableConfig(config.Executable); err != nil {
-		return err
-	}
-	return nil
+	return validateExecutableConfig(config.Executable)
 }
 
 func getStaticConfigFromFile(staticConfigFile string) (PrimaryStaticLauncherConfig, error) {

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -45,8 +45,8 @@ type StaticLauncherConfig struct {
 }
 
 type PrimaryStaticLauncherConfig struct {
-	StaticLauncherConfig                         `yaml:",inline"`
-	SubProcesses map[string]StaticLauncherConfig `yaml:"sub-processes"`
+	StaticLauncherConfig `yaml:",inline"`
+	SubProcesses         map[string]StaticLauncherConfig `yaml:"sub-processes"`
 }
 
 type CustomLauncherConfig struct {

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -346,6 +346,18 @@ subProcesses:
 `,
 		},
 		{
+			name: "invalid subProcess name",
+			msg:  "invalid subProcess name '../breakout' in static config: subProcess name '../breakout' does not match required pattern '.+'",
+			data: `
+configType: executable
+configVersion: 1
+executable: postgres
+subProcesses:
+  ../breakout:
+    configType: java
+`,
+		},
+		{
 			name: "invalid executable",
 			msg:  `Can handle executable\=\{.+\} only, found /bin/rm`,
 			data: `

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -24,7 +24,7 @@ func TestParseStaticConfig(t *testing.T) {
 	for i, currCase := range []struct {
 		name string
 		data string
-		want StaticLauncherConfig
+		want PrimaryStaticLauncherConfig
 	}{
 		{
 			name: "java static config",
@@ -46,7 +46,7 @@ args:
   - arg1
   - arg2
 `,
-			want: StaticLauncherConfig{
+			want: PrimaryStaticLauncherConfig{
 				LauncherConfig: LauncherConfig{
 					ConfigType:    "java",
 					ConfigVersion: 1,
@@ -78,7 +78,7 @@ args:
   - arg1
   - arg2
 `,
-			want: StaticLauncherConfig{
+			want: PrimaryStaticLauncherConfig{
 				LauncherConfig: LauncherConfig{
 					ConfigType:    "executable",
 					ConfigVersion: 1,
@@ -101,7 +101,7 @@ func TestParseCustomConfig(t *testing.T) {
 	for i, currCase := range []struct {
 		name string
 		data string
-		want CustomLauncherConfig
+		want PrimaryCustomLauncherConfig
 	}{
 		{
 			name: "java custom config",
@@ -115,7 +115,7 @@ jvmOpts:
   - jvmOpt1
   - jvmOpt2
 `,
-			want: CustomLauncherConfig{
+			want: PrimaryCustomLauncherConfig{
 				LauncherConfig: LauncherConfig{
 					ConfigType:    "java",
 					ConfigVersion: 1,
@@ -136,7 +136,7 @@ jvmOpts:
   - jvmOpt1
   - jvmOpt2
 `,
-			want: CustomLauncherConfig{
+			want: PrimaryCustomLauncherConfig{
 				LauncherConfig: LauncherConfig{
 					ConfigType:    "java",
 					ConfigVersion: 1,
@@ -155,7 +155,7 @@ jvmOpts:
   - jvmOpt1
   - jvmOpt2
 `,
-			want: CustomLauncherConfig{
+			want: PrimaryCustomLauncherConfig{
 				LauncherConfig: LauncherConfig{
 					ConfigType:    "java",
 					ConfigVersion: 1,
@@ -175,7 +175,7 @@ env:
   SOME_ENV_VAR: /etc/profile
   OTHER_ENV_VAR: /etc/redhat-release
 `,
-			want: CustomLauncherConfig{
+			want: PrimaryCustomLauncherConfig{
 				LauncherConfig: LauncherConfig{
 					ConfigType:    "executable",
 					ConfigVersion: 1,
@@ -200,7 +200,7 @@ func TestParseStaticConfigFailures(t *testing.T) {
 	}{
 		{
 			name: "bad YAML",
-			msg:  `Failed to deserialize Static Launcher Config, please check the syntax of your configuration file`,
+			msg:  `Failed to deserialize Static Launcher Config, please StartProcessLivelinessCheck the syntax of your configuration file`,
 			data: `
 bad: yaml:
 `,

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -138,7 +138,7 @@ subProcesses:
 						TypedConfig: TypedConfig{
 							Type: "executable",
 						},
-						Executable: "/etc/bin/envoy",
+						Executable: "/etc/envoy/envoy",
 						Args:       []string{"arg3"},
 					},
 				},
@@ -334,14 +334,14 @@ executable: postgres
 `,
 		},
 		{
-			name: "invalid subProcess",
-			msg:  `Can handle configType\=\{1\} only, found config`,
+			name: "invalid subProcess config type",
+			msg:  `failed to validate subProcess launcher configuration 'incorrect': Can handle configType\=\{.+\} only, found config`,
 			data: `
 configType: executable
 configVersion: 1
 executable: postgres
 subProcesses:
-  subProcess:
+  incorrect:
     configType: config
 `,
 		},

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -100,7 +100,7 @@ args:
 			},
 		},
 		{
-			name: "with sub-process config",
+			name: "with subProcess config",
 			data: `
 configType: executable
 configVersion: 1
@@ -232,7 +232,7 @@ jvmOpts:
 			},
 		},
 		{
-			name: "java custom config with sub-process",
+			name: "java custom config with subProcess",
 			data: `
 configType: java
 configVersion: 1
@@ -334,14 +334,14 @@ executable: postgres
 `,
 		},
 		{
-			name: "invalid subprocess",
+			name: "invalid subProcess",
 			msg:  `Can handle configType\=\{1\} only, found config`,
 			data: `
 configType: executable
 configVersion: 1
 executable: postgres
 subProcesses:
-  sub-process:
+  subProcess:
     configType: config
 `,
 		},

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -47,21 +47,23 @@ args:
   - arg2
 `,
 			want: PrimaryStaticLauncherConfig{
-				LauncherConfig: LauncherConfig{
-					ConfigType:    "java",
-					ConfigVersion: 1,
-				},
-				Env: map[string]string{
-					"SOME_ENV_VAR":  "/etc/profile",
-					"OTHER_ENV_VAR": "/etc/redhat-release",
-				},
-				Executable: "java",
-				Args:       []string{"arg1", "arg2"},
-				JavaConfig: JavaConfig{
-					MainClass: "mainClass",
-					JavaHome:  "javaHome",
-					Classpath: []string{"classpath1", "classpath2"},
-					JvmOpts:   []string{"jvmOpt1", "jvmOpt2"},
+				StaticLauncherConfig: StaticLauncherConfig{
+					LauncherConfig: LauncherConfig{
+						ConfigType:    "java",
+						ConfigVersion: 1,
+					},
+					Env: map[string]string{
+						"SOME_ENV_VAR":  "/etc/profile",
+						"OTHER_ENV_VAR": "/etc/redhat-release",
+					},
+					Executable: "java",
+					Args:       []string{"arg1", "arg2"},
+					JavaConfig: JavaConfig{
+						MainClass: "mainClass",
+						JavaHome:  "javaHome",
+						Classpath: []string{"classpath1", "classpath2"},
+						JvmOpts:   []string{"jvmOpt1", "jvmOpt2"},
+					},
 				},
 			},
 		},
@@ -79,20 +81,22 @@ args:
   - arg2
 `,
 			want: PrimaryStaticLauncherConfig{
-				LauncherConfig: LauncherConfig{
-					ConfigType:    "executable",
-					ConfigVersion: 1,
+				StaticLauncherConfig: StaticLauncherConfig{
+					LauncherConfig: LauncherConfig{
+						ConfigType:    "executable",
+						ConfigVersion: 1,
+					},
+					Env: map[string]string{
+						"SOME_ENV_VAR":  "/etc/profile",
+						"OTHER_ENV_VAR": "/etc/redhat-release",
+					},
+					Executable: "/usr/bin/postgres",
+					Args:       []string{"arg1", "arg2"},
 				},
-				Env: map[string]string{
-					"SOME_ENV_VAR":  "/etc/profile",
-					"OTHER_ENV_VAR": "/etc/redhat-release",
-				},
-				Executable: "/usr/bin/postgres",
-				Args:       []string{"arg1", "arg2"},
 			},
 		},
 	} {
-		got, _ := ParseStaticConfig([]byte(currCase.data))
+		got, _ := parseStaticConfig([]byte(currCase.data))
 		assert.Equal(t, currCase.want, got, "Case %d: %s", i, currCase.name)
 	}
 }
@@ -116,15 +120,17 @@ jvmOpts:
   - jvmOpt2
 `,
 			want: PrimaryCustomLauncherConfig{
-				LauncherConfig: LauncherConfig{
-					ConfigType:    "java",
-					ConfigVersion: 1,
+				CustomLauncherConfig: CustomLauncherConfig{
+					LauncherConfig: LauncherConfig{
+						ConfigType:    "java",
+						ConfigVersion: 1,
+					},
+					Env: map[string]string{
+						"SOME_ENV_VAR":  "/etc/profile",
+						"OTHER_ENV_VAR": "/etc/redhat-release",
+					},
+					JvmOpts: []string{"jvmOpt1", "jvmOpt2"},
 				},
-				Env: map[string]string{
-					"SOME_ENV_VAR":  "/etc/profile",
-					"OTHER_ENV_VAR": "/etc/redhat-release",
-				},
-				JvmOpts: []string{"jvmOpt1", "jvmOpt2"},
 			},
 		},
 		{
@@ -137,11 +143,13 @@ jvmOpts:
   - jvmOpt2
 `,
 			want: PrimaryCustomLauncherConfig{
-				LauncherConfig: LauncherConfig{
-					ConfigType:    "java",
-					ConfigVersion: 1,
+				CustomLauncherConfig: CustomLauncherConfig{
+					LauncherConfig: LauncherConfig{
+						ConfigType:    "java",
+						ConfigVersion: 1,
+					},
+					JvmOpts: []string{"jvmOpt1", "jvmOpt2"},
 				},
-				JvmOpts: []string{"jvmOpt1", "jvmOpt2"},
 			},
 		},
 		{
@@ -156,14 +164,16 @@ jvmOpts:
   - jvmOpt2
 `,
 			want: PrimaryCustomLauncherConfig{
-				LauncherConfig: LauncherConfig{
-					ConfigType:    "java",
-					ConfigVersion: 1,
+				CustomLauncherConfig: CustomLauncherConfig{
+					LauncherConfig: LauncherConfig{
+						ConfigType:    "java",
+						ConfigVersion: 1,
+					},
+					Env: map[string]string{
+						"SOME_ENV_VAR": "{{CWD}}/etc/profile",
+					},
+					JvmOpts: []string{"jvmOpt1", "jvmOpt2"},
 				},
-				Env: map[string]string{
-					"SOME_ENV_VAR": "{{CWD}}/etc/profile",
-				},
-				JvmOpts: []string{"jvmOpt1", "jvmOpt2"},
 			},
 		},
 		{
@@ -176,18 +186,20 @@ env:
   OTHER_ENV_VAR: /etc/redhat-release
 `,
 			want: PrimaryCustomLauncherConfig{
-				LauncherConfig: LauncherConfig{
-					ConfigType:    "executable",
-					ConfigVersion: 1,
-				},
-				Env: map[string]string{
-					"SOME_ENV_VAR":  "/etc/profile",
-					"OTHER_ENV_VAR": "/etc/redhat-release",
+				CustomLauncherConfig: CustomLauncherConfig{
+					LauncherConfig: LauncherConfig{
+						ConfigType:    "executable",
+						ConfigVersion: 1,
+					},
+					Env: map[string]string{
+						"SOME_ENV_VAR":  "/etc/profile",
+						"OTHER_ENV_VAR": "/etc/redhat-release",
+					},
 				},
 			},
 		},
 	} {
-		got, _ := ParseCustomConfig([]byte(currCase.data))
+		got, _ := parseCustomConfig([]byte(currCase.data))
 		assert.Equal(t, currCase.want, got, "Case %d: %s", i, currCase.name)
 	}
 }
@@ -272,7 +284,7 @@ mainClass: hello.world
 `,
 		},
 	} {
-		_, err := ParseStaticConfig([]byte(currCase.data))
+		_, err := parseStaticConfig([]byte(currCase.data))
 		assert.NotEqual(t, err, nil, "Case %d: %s had no errors", i, currCase.name)
 		assert.Regexp(t, currCase.msg, err.Error(), "Case %d: %s had the wrong error message", i, currCase.name)
 	}

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -58,10 +58,10 @@ func CompileCmdsFromConfig(staticConfig *PrimaryStaticLauncherConfig, customConf
 	for name, subProcStatic := range staticConfig.SubProcesses {
 		subProcCustom, ok := customConfig.SubProcesses[name]
 		if !ok {
-			return ServiceCommands{}, errors.Errorf("no custom launcher config exists for sub-process config '%s'", name)
+			return ServiceCommands{}, errors.Errorf("no custom launcher config exists for subProcess config '%s'", name)
 		}
 		if cmds.SubProcesses[name], err = CompileCmdFromConfig(&subProcStatic, &subProcCustom, stdout); err != nil {
-			return ServiceCommands{}, errors.Wrapf(err, "unable to compile command for sub-process config '%s'", name)
+			return ServiceCommands{}, errors.Wrapf(err, "unable to compile command for subProcess config '%s'", name)
 		}
 	}
 	return cmds, nil

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -61,8 +61,12 @@ func CompileCmdsFromConfig(staticConfig *PrimaryStaticLauncherConfig, customConf
 		return ServiceCommands{}, err
 	}
 
-	for name, static := range staticConfig.Secondaries {
-		if cmds.Secondaries[name], err = CompileCmdFromConfig(&static, &customConfig[name]); err != nil {
+	for name, staticSecondary := range staticConfig.Secondaries {
+		customSecondary, ok := customConfig.Secondaries[name]
+		if !ok {
+			return ServiceCommands{}, errors.Errorf("no custom launcher config exists for secondary config '%s'", name)
+		}
+		if cmds.Secondaries[name], err = CompileCmdFromConfig(&staticSecondary, &customSecondary); err != nil {
 			return ServiceCommands{}, errors.Wrapf(err, "unable to compile command for secondary config '%s'", name)
 		}
 	}

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -39,14 +39,14 @@ type ServiceCommands struct {
 }
 
 func CompileCmdsFromConfigFiles(staticConfigFile, customConfigFile string, stdout io.Writer) (ServiceCommands, error) {
-	staticConfig, customConfig, err := GetConfigsFromFiles(staticConfigFile, customConfigFile, stdout io.Writer)
+	staticConfig, customConfig, err := GetConfigsFromFiles(staticConfigFile, customConfigFile, stdout)
 	if err != nil {
 		return ServiceCommands{}, err
 	}
-	return CompileCmdsFromConfig(&staticConfig, &customConfig)
+	return CompileCmdsFromConfig(&staticConfig, &customConfig, stdout)
 }
 
-func CompileCmdsFromConfig(staticConfig *PrimaryStaticLauncherConfig, customConfig *PrimaryCustomLauncherConfig) (ServiceCommands, error) {
+func CompileCmdsFromConfig(staticConfig *PrimaryStaticLauncherConfig, customConfig *PrimaryCustomLauncherConfig, stdout io.Writer) (ServiceCommands, error) {
 	cmds := ServiceCommands{
 		Secondaries: make(map[string]*exec.Cmd),
 	}
@@ -60,7 +60,7 @@ func CompileCmdsFromConfig(staticConfig *PrimaryStaticLauncherConfig, customConf
 		if !ok {
 			return ServiceCommands{}, errors.Errorf("no custom launcher config exists for secondary config '%s'", name)
 		}
-		if cmds.Secondaries[name], err = CompileCmdFromConfig(&staticSecondary, &customSecondary); err != nil {
+		if cmds.Secondaries[name], err = CompileCmdFromConfig(&staticSecondary, &customSecondary, stdout); err != nil {
 			return ServiceCommands{}, errors.Wrapf(err, "unable to compile command for secondary config '%s'", name)
 		}
 	}

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -38,17 +38,11 @@ type ServiceCommands struct {
 	Secondaries map[string]*exec.Cmd
 }
 
-func CompileCmdsFromConfigFiles(staticConfigFile, customConfigFile string, stdout io.Writer) (*exec.Cmd, error) {
-	staticConfig, staticConfigErr := GetStaticConfigFromFile(staticConfigFile)
-	if staticConfigErr != nil {
-		return ServiceCommands{}, staticConfigErr
+func CompileCmdsFromConfigFiles(staticConfigFile, customConfigFile string, stdout io.Writer) (ServiceCommands, error) {
+	staticConfig, customConfig, err := GetConfigsFromFiles(staticConfigFile, customConfigFile, stdout io.Writer)
+	if err != nil {
+		return ServiceCommands{}, err
 	}
-
-	customConfig, customConfigErr := GetCustomConfigFromFile(customConfigFile, staticConfig, stdout)
-	if customConfigErr != nil {
-		return ServiceCommands{}, customConfigErr
-	}
-
 	return CompileCmdsFromConfig(&staticConfig, &customConfig)
 }
 

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -34,8 +34,8 @@ const (
 )
 
 type ServiceCommands struct {
-	Primary     *exec.Cmd
-	Secondaries map[string]*exec.Cmd
+	Primary      *exec.Cmd
+	SubProcesses map[string]*exec.Cmd
 }
 
 func CompileCmdsFromConfigFiles(staticConfigFile, customConfigFile string, stdout io.Writer) (ServiceCommands, error) {
@@ -48,20 +48,20 @@ func CompileCmdsFromConfigFiles(staticConfigFile, customConfigFile string, stdou
 
 func CompileCmdsFromConfig(staticConfig *PrimaryStaticLauncherConfig, customConfig *PrimaryCustomLauncherConfig, stdout io.Writer) (ServiceCommands, error) {
 	cmds := ServiceCommands{
-		Secondaries: make(map[string]*exec.Cmd),
+		SubProcesses: make(map[string]*exec.Cmd),
 	}
 	var err error
 	if cmds.Primary, err = CompileCmdFromConfig(&staticConfig.StaticLauncherConfig, &customConfig.CustomLauncherConfig, stdout); err != nil {
 		return ServiceCommands{}, err
 	}
 
-	for name, staticSecondary := range staticConfig.Secondaries {
-		customSecondary, ok := customConfig.Secondaries[name]
+	for name, subProcStatic := range staticConfig.SubProcesses {
+		subProcCustom, ok := customConfig.SubProcesses[name]
 		if !ok {
-			return ServiceCommands{}, errors.Errorf("no custom launcher config exists for secondary config '%s'", name)
+			return ServiceCommands{}, errors.Errorf("no custom launcher config exists for sub-process config '%s'", name)
 		}
-		if cmds.Secondaries[name], err = CompileCmdFromConfig(&staticSecondary, &customSecondary, stdout); err != nil {
-			return ServiceCommands{}, errors.Wrapf(err, "unable to compile command for secondary config '%s'", name)
+		if cmds.SubProcesses[name], err = CompileCmdFromConfig(&subProcStatic, &subProcCustom, stdout); err != nil {
+			return ServiceCommands{}, errors.Wrapf(err, "unable to compile command for sub-process config '%s'", name)
 		}
 	}
 	return cmds, nil

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -79,7 +79,7 @@ func CompileCmdFromConfig(staticConfig *StaticLauncherConfig, customConfig *Cust
 	var executable string
 	var executableErr error
 
-	if staticConfig.ConfigType == "java" {
+	if staticConfig.Type == "java" {
 		javaHome, javaHomeErr := getJavaHome(staticConfig.JavaConfig.JavaHome)
 		if javaHomeErr != nil {
 			return nil, javaHomeErr
@@ -98,14 +98,14 @@ func CompileCmdFromConfig(staticConfig *StaticLauncherConfig, customConfig *Cust
 		args = append(args, customConfig.JvmOpts...)
 		args = append(args, "-classpath", classpath)
 		args = append(args, staticConfig.JavaConfig.MainClass)
-	} else if staticConfig.ConfigType == "executable" {
+	} else if staticConfig.Type == "executable" {
 		executable, executableErr = verifyPathIsSafeForExec(staticConfig.Executable)
 		if executableErr != nil {
 			return nil, executableErr
 		}
 		args = append(args, executable) // 0th argument is the command itself
 	} else {
-		return nil, fmt.Errorf("You can't launch type %v, this should have errored in config validation", staticConfig.ConfigType)
+		return nil, fmt.Errorf("You can't launch type %v, this should have errored in config validation", staticConfig.Type)
 	}
 
 	args = append(args, staticConfig.Args...)

--- a/launchlib/monitor.go
+++ b/launchlib/monitor.go
@@ -1,0 +1,70 @@
+package launchlib
+
+import (
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	CheckPeriod = 5 * time.Second
+)
+
+type ProcessMonitor struct {
+	ServicePid     int
+	ServiceGroupId int
+}
+
+func (m *ProcessMonitor) TermProcessGroupOnDeath() error {
+	if err := m.verify(); err != nil {
+		return err
+	}
+
+	tick := time.NewTicker(CheckPeriod)
+	alive := true
+	for {
+		select {
+		case <-tick.C:
+			alive = m.isAlive()
+		}
+		if !alive {
+			tick.Stop()
+			break
+		}
+	}
+
+	// Service process has died, terminating process group
+	if err := syscall.Kill(-m.ServiceGroupId, syscall.SIGTERM); err != nil {
+		return errors.Wrapf(err, "unable to set term signal to process group, beware of orphaned secondary services")
+	}
+	return nil
+}
+
+func (m *ProcessMonitor) verify() error {
+	if syscall.Getpgrp() != m.ServiceGroupId {
+		return errors.Errorf("ProcessMonitor is part of process group '%s' not service process group '%s'. "+
+			"ProcessMonitor is expected to only be used by the go-java-launcher itself, under the same process as the"+
+			" service", syscall.Getpgrp(), m.ServiceGroupId)
+	}
+
+	if m.ServiceGroupId == 1 {
+		return errors.New("ProcessMonitor service group given is '1', refusing to monitor services under " +
+			"init process group")
+	}
+	return nil
+}
+
+func (m *ProcessMonitor) isAlive() bool {
+	process, err := os.FindProcess(m.ServicePid)
+	if err != nil {
+		return false
+	}
+
+	err = process.Signal(syscall.Signal(0))
+	if err != nil {
+		return false
+	}
+	return true
+}

--- a/launchlib/monitor.go
+++ b/launchlib/monitor.go
@@ -51,7 +51,7 @@ func (m *ProcessMonitor) TermProcessGroupOnDeath() error {
 
 	// Service process has died, terminating process group
 	if err := syscall.Kill(-m.ProcessGroupPID, syscall.SIGTERM); err != nil {
-		return errors.Wrapf(err, "unable to send term signal to process group, beware of orphaned sub-processes")
+		return errors.Wrapf(err, "unable to send term signal to process group, beware of orphaned subProcesses")
 	}
 	return nil
 }

--- a/launchlib/monitor.go
+++ b/launchlib/monitor.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package launchlib
 
 import (

--- a/launchlib/monitor.go
+++ b/launchlib/monitor.go
@@ -51,7 +51,7 @@ func (m *ProcessMonitor) TermProcessGroupOnDeath() error {
 
 	// Service process has died, terminating process group
 	if err := syscall.Kill(-m.ProcessGroupPID, syscall.SIGTERM); err != nil {
-		return errors.Wrapf(err, "unable to set term signal to process group, beware of orphaned secondary services")
+		return errors.Wrapf(err, "unable to send term signal to process group, beware of orphaned sub-processes")
 	}
 	return nil
 }

--- a/launchlib/monitor.go
+++ b/launchlib/monitor.go
@@ -28,7 +28,7 @@ const (
 
 type ProcessMonitor struct {
 	ServicePid     int
-	ServiceGroupId int
+	ServiceGroupID int
 }
 
 func (m *ProcessMonitor) TermProcessGroupOnDeath() error {
@@ -50,20 +50,20 @@ func (m *ProcessMonitor) TermProcessGroupOnDeath() error {
 	}
 
 	// Service process has died, terminating process group
-	if err := syscall.Kill(-m.ServiceGroupId, syscall.SIGTERM); err != nil {
+	if err := syscall.Kill(-m.ServiceGroupID, syscall.SIGTERM); err != nil {
 		return errors.Wrapf(err, "unable to set term signal to process group, beware of orphaned secondary services")
 	}
 	return nil
 }
 
 func (m *ProcessMonitor) verify() error {
-	if syscall.Getpgrp() != m.ServiceGroupId {
+	if syscall.Getpgrp() != m.ServiceGroupID {
 		return errors.Errorf("ProcessMonitor is part of process group '%s' not service process group '%s'. "+
 			"ProcessMonitor is expected to only be used by the go-java-launcher itself, under the same process as the"+
-			" service", syscall.Getpgrp(), m.ServiceGroupId)
+			" service", syscall.Getpgrp(), m.ServiceGroupID)
 	}
 
-	if m.ServiceGroupId == 1 {
+	if m.ServiceGroupID == 1 {
 		return errors.New("ProcessMonitor service group given is '1', refusing to monitor services under " +
 			"init process group")
 	}


### PR DESCRIPTION
Addition of `secondaries` configuration block can include additional launcher configurations of named processes.

Running the launcher will result in the forking and subsequent execution of secondary process, as well as a monitor for the process group, before executing the primary process.  The additional monitor process will send a kill signal to the process group after the primary process dies.