### PR TITLE
Process groups cannot be created in restricted permission environments

### DIFF
--- a/init/cli/lib.go
+++ b/init/cli/lib.go
@@ -110,6 +110,7 @@ func getConfiguredCommands(ctx cli.Context, loggers launchlib.ServiceLoggers) (m
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to compile commands from static and custom configurations")
 	}
+
 	cmds := make(map[string]CommandContext)
 	cmds[staticConfig.ServiceName] = CommandContext{
 		serviceCmds.Primary,

--- a/integration_test/jdk/bin/java
+++ b/integration_test/jdk/bin/java
@@ -1,10 +1,15 @@
 #!/bin/sh
 
+trap 'echo "Caught SIGPOLL"' 29
+
 echo
 echo "main method"
 
-if [ -z $SLEEP_TIME ]; then
-    sleep 5
-else
-    sleep $SLEEP_TIME
-fi
+# sleep stops execution of the current process including echoing that a signal was received
+# breaking up the sleep gives time between sleeps for the trap to happen
+SLEEP_TIME=${SLEEP_TIME:-5}
+COUNTER=0
+while [ $COUNTER -lt $SLEEP_TIME ]; do
+    sleep 1 > /dev/null 2>&1
+    COUNTER=$((COUNTER+1))
+done

--- a/integration_test/testdata/launcher-custom-multiprocess-long-sub-process.yml
+++ b/integration_test/testdata/launcher-custom-multiprocess-long-sub-process.yml
@@ -1,0 +1,11 @@
+configType: java
+configVersion: 1
+jvmOpts:
+  - '-Xmx1g'
+subProcesses:
+  sidecar:
+    configType: java
+    env:
+      SLEEP_TIME: "200"
+    jvmOpts:
+      - '-Xmx1g'


### PR DESCRIPTION
Setting the process group requires elevated privileges in some environments as it uses the `setgid` capability.

Ideally `go-java-launcher` should not require any additional privileges to run.