### PR TITLE
[fix] Discard getServiceStatus logging to avoid log explosion

### DIFF
--- a/init/cli/logging.go
+++ b/init/cli/logging.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -77,4 +78,16 @@ func (f *FileLoggers) OpenFile(path string) (*os.File, error) {
 		return file, errors.Wrapf(err, "could not open logging file '%s'", path)
 	}
 	return file, nil
+}
+
+var devNull = launchlib.NoopClosingWriter{Writer: ioutil.Discard}
+
+type DevNullLoggers struct{}
+
+func (d *DevNullLoggers) PrimaryLogger() (io.WriteCloser, error) {
+	return &devNull, nil
+}
+
+func (d *DevNullLoggers) SubProcessLogger(name string) launchlib.CreateLogger {
+	return d.PrimaryLogger
 }

--- a/init/cli/status.go
+++ b/init/cli/status.go
@@ -36,7 +36,8 @@ If exit code is nonzero, writes an error message to stderr and var/log/startup.l
 }
 
 func status(ctx cli.Context, loggers launchlib.ServiceLoggers) error {
-	serviceStatus, err := getServiceStatus(ctx, loggers)
+	// Executed with logging for errors, however we discard the verbose logging of getServiceStatus
+	serviceStatus, err := getServiceStatus(ctx, &DevNullLoggers{})
 	if err != nil {
 		return logErrorAndReturnWithExitCode(ctx, errors.Wrap(err, "failed to determine service status"), 4)
 	}


### PR DESCRIPTION
Querying the service status can happen any number of times between
service 'start's.  Since log truncating only happens on start, this
can cause unchecked growth of service loggers.