### PR TITLE
[improvement] Separate pids.yaml into separate <name>.pid files representing each subcommand

### DIFF
--- a/integration_test/testdata/launcher-static-bad-java-home.yml
+++ b/integration_test/testdata/launcher-static-bad-java-home.yml
@@ -1,5 +1,6 @@
 configType: java
 configVersion: 1
+serviceName: primary
 mainClass: Main
 classpath:
   - ./testdata/

--- a/integration_test/testdata/launcher-static-with-dirs.yml
+++ b/integration_test/testdata/launcher-static-with-dirs.yml
@@ -1,6 +1,7 @@
 configType: java
 configVersion: 1
 mainClass: Main
+serviceName: primary
 classpath:
   - ./testdata/
 jvmOpts:

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	subProcessNamePattern = regexp.MustCompile("^[a-z-]+$")
+	processNamePattern = regexp.MustCompile("^[a-z-]+$")
 )
 
 type VersionedConfig struct {
@@ -130,12 +130,9 @@ func validateSubProcessLimit(numberSubProcesses int) error {
 	return nil
 }
 
-func validateSubProcessName(name string) error {
-	if !subProcessNamePattern.MatchString(name) {
-		return errors.Errorf(
-			"subProcess name '%s' does not match required pattern '%s'",
-			name,
-			subProcessNamePattern)
+func validateProcessName(name string) error {
+	if !processNamePattern.MatchString(name) {
+		return errors.Errorf("process name '%s' does not match required pattern '%s'", name, processNamePattern)
 	}
 	return nil
 }
@@ -152,6 +149,11 @@ func parseStaticConfig(yamlString []byte) (PrimaryStaticLauncherConfig, error) {
 		return PrimaryStaticLauncherConfig{}, err
 	}
 
+	if err := validateProcessName(config.ServiceName); err != nil {
+		return PrimaryStaticLauncherConfig{},
+			errors.Wrapf(err, "invalid service name '%s' in static config", config.ServiceName)
+	}
+
 	if err := validateStaticConfig(&config.StaticLauncherConfig); err != nil {
 		return PrimaryStaticLauncherConfig{}, err
 	}
@@ -161,7 +163,7 @@ func parseStaticConfig(yamlString []byte) (PrimaryStaticLauncherConfig, error) {
 	}
 
 	for name, subProcess := range config.SubProcesses {
-		if err := validateSubProcessName(name); err != nil {
+		if err := validateProcessName(name); err != nil {
 			return PrimaryStaticLauncherConfig{},
 				errors.Wrapf(err, "invalid subProcess name '%s' in static config", name)
 		}
@@ -248,7 +250,7 @@ func parseCustomConfig(yamlString []byte) (PrimaryCustomLauncherConfig, error) {
 	}
 
 	for name, subProcess := range config.SubProcesses {
-		if err := validateSubProcessName(name); err != nil {
+		if err := validateProcessName(name); err != nil {
 			return PrimaryCustomLauncherConfig{}, errors.Wrapf(err, "invalid subProcess name '%s' in "+
 				"custom config", name)
 		}


### PR DESCRIPTION
Gives consistency with the format before the addition of subprocesses, and
provides a much simpler way for external processes to access pid information
since they no longer have to parse the yaml.

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

## After this PR
<!-- Describe at a high-level why this approach is better. -->

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
