### PR TITLE
[fix] Allow digits in process name

### DIFF
--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	processNamePattern = regexp.MustCompile("^[a-z-]+$")
+	processNamePattern = regexp.MustCompile("^[a-z0-9-]+$")
 )
 
 type VersionedConfig struct {


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
```
Attaching to build2.palantir.pt
build2.palantir.pt  | Failed to read config files invalid service name 'build2' in static config: process name 'build2' does not match required pattern '^[a-z-]+$'
build2.palantir.pt  | panic: invalid service name 'build2' in static config: process name 'build2' does not match required pattern '^[a-z-]+$'
build2.palantir.pt  |
build2.palantir.pt  | goroutine 1 [running]:
build2.palantir.pt  | main.main()
build2.palantir.pt  |   /go/src/github.com/palantir/go-java-launcher/launcher/main/main.go:98 +0x135c
build2.palantir.pt exited with code 2
```
## After this PR

The above failure doesnt happen