### PR TITLE
[fix] Trim whitespace from pidfile content

### DIFF
--- a/init/cli/lib.go
+++ b/init/cli/lib.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/palantir/pkg/cli"
@@ -102,7 +103,7 @@ func getCmdProcess(name string) (*int, *os.Process, error) {
 		return nil, nil, errors.Wrap(err, "failed to read pidfile")
 	}
 
-	pid, err := strconv.Atoi(string(pidBytes))
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "pid file did not contain an integer")
 	}


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
We saw the below error in production:
```
failed to determine service status: failed to determine running processes: pid file did not contain an integer: strconv.Atoi: parsing "12773\n": invalid syntax
```

From reading the `Start` code I'm not sure how the newline got in there, but this should protect us from it in the future.

## After this PR
We will ignore spurious whitespace in the pidfile

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/go-java-launcher/84)
<!-- Reviewable:end -->
