### PR TITLE
[fix] SIGKILL after 2 minutes, not 4

### DIFF
--- a/init/cli/stop.go
+++ b/init/cli/stop.go
@@ -38,7 +38,7 @@ var stopCliCommand = cli.Command{
 	Usage: `
 Ensures the service defined by the static and custom configurations are service/bin/launcher-static.yml and
 var/conf/launcher-custom.yml is not running. If successful, exits 0, otherwise exits 1 and writes an error message to
-stderr and var/log/startup.log. Waits for at least 120 seconds for any processes to stop before sending a SIGKILL.`,
+stderr and var/log/startup.log. Waits for at least 110 seconds for any processes to stop before sending a SIGKILL.`,
 	Action: executeWithLoggers(stop, NewAlwaysAppending()),
 }
 
@@ -95,7 +95,7 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 }
 
 func waitForServiceToStop(ctx cli.Context, procs map[string]*os.Process) error {
-	const numSecondsToWait = 120
+	const numSecondsToWait = 110
 	timer := Clock.NewTimer(numSecondsToWait * time.Second)
 	defer timer.Stop()
 

--- a/init/cli/stop.go
+++ b/init/cli/stop.go
@@ -38,7 +38,7 @@ var stopCliCommand = cli.Command{
 	Usage: `
 Ensures the service defined by the static and custom configurations are service/bin/launcher-static.yml and
 var/conf/launcher-custom.yml is not running. If successful, exits 0, otherwise exits 1 and writes an error message to
-stderr and var/log/startup.log. Waits for at least 240 seconds for any processes to stop before sending a SIGKILL.`,
+stderr and var/log/startup.log. Waits for at least 120 seconds for any processes to stop before sending a SIGKILL.`,
 	Action: executeWithLoggers(stop, NewAlwaysAppending()),
 }
 
@@ -95,7 +95,7 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 }
 
 func waitForServiceToStop(ctx cli.Context, procs map[string]*os.Process) error {
-	const numSecondsToWait = 240
+	const numSecondsToWait = 120
 	timer := Clock.NewTimer(numSecondsToWait * time.Second)
 	defer timer.Stop()
 

--- a/integration_test/go_init_integration_test.go
+++ b/integration_test/go_init_integration_test.go
@@ -713,7 +713,7 @@ func TestInitStop_Unstoppable_OneWrittenOneRunning(t *testing.T) {
 	assert.Equal(t, 0, result.exitCode)
 	assert.Empty(t, result.stderr)
 	assert.Contains(t, result.startupLog, "processes")
-	assert.Contains(t, result.startupLog, "did not stop within 240 seconds, so a SIGKILL was sent")
+	assert.Contains(t, result.startupLog, "did not stop within 120 seconds, so a SIGKILL was sent")
 }
 
 // (2, 1)
@@ -729,7 +729,7 @@ func TestInitStop_Unstoppable_TwoWrittenOneRunning(t *testing.T) {
 	assert.Equal(t, 0, result.exitCode)
 	assert.Empty(t, result.stderr)
 	assert.Contains(t, result.startupLog, "processes")
-	assert.Contains(t, result.startupLog, "did not stop within 240 seconds, so a SIGKILL was sent")
+	assert.Contains(t, result.startupLog, "did not stop within 120 seconds, so a SIGKILL was sent")
 }
 
 // (2, 2)
@@ -748,7 +748,7 @@ func TestInitStop_Unstoppable_TwoWrittenTwoRunning(t *testing.T) {
 	assert.Equal(t, 0, result.exitCode)
 	assert.Empty(t, result.stderr)
 	assert.Contains(t, result.startupLog, "processes")
-	assert.Contains(t, result.startupLog, "did not stop within 240 seconds, so a SIGKILL was sent")
+	assert.Contains(t, result.startupLog, "did not stop within 120 seconds, so a SIGKILL was sent")
 }
 
 func forkKillableSleep(t *testing.T) (pid int, killer func()) {
@@ -935,18 +935,18 @@ func readFromChannel(c <-chan initResult, timeout time.Duration) (result *initRe
 	}
 }
 
-// Runs init 'stop' and asserts that it will time out after 240 seconds.
+// Runs init 'stop' and asserts that it will time out after 120 seconds.
 func runStopAssertTimesOut(t *testing.T) *initResult {
 	clock := time2.NewFakeClock()
 	initChan := runInitWithClock(t, clock, "stop")
 	clock.BlockUntil(2) // wait for timer and ticker to attach
-	clock.Advance(239 * time.Second)
+	clock.Advance(119 * time.Second)
 	result := readFromChannel(initChan, 1*time.Second)
-	require.Nil(t, result, "Expected `stop` to still wait after 239 seconds")
+	require.Nil(t, result, "Expected `stop` to still wait after 119 seconds")
 
 	clock.Advance(1 * time.Second)
 	result2 := readFromChannel(initChan, 1*time.Second)
-	require.NotNil(t, result2, "Expected `stop` to finish after 240 seconds")
+	require.NotNil(t, result2, "Expected `stop` to finish after 120 seconds")
 
 	return result2
 }

--- a/integration_test/go_init_integration_test.go
+++ b/integration_test/go_init_integration_test.go
@@ -713,7 +713,7 @@ func TestInitStop_Unstoppable_OneWrittenOneRunning(t *testing.T) {
 	assert.Equal(t, 0, result.exitCode)
 	assert.Empty(t, result.stderr)
 	assert.Contains(t, result.startupLog, "processes")
-	assert.Contains(t, result.startupLog, "did not stop within 120 seconds, so a SIGKILL was sent")
+	assert.Contains(t, result.startupLog, "did not stop within 110 seconds, so a SIGKILL was sent")
 }
 
 // (2, 1)
@@ -729,7 +729,7 @@ func TestInitStop_Unstoppable_TwoWrittenOneRunning(t *testing.T) {
 	assert.Equal(t, 0, result.exitCode)
 	assert.Empty(t, result.stderr)
 	assert.Contains(t, result.startupLog, "processes")
-	assert.Contains(t, result.startupLog, "did not stop within 120 seconds, so a SIGKILL was sent")
+	assert.Contains(t, result.startupLog, "did not stop within 110 seconds, so a SIGKILL was sent")
 }
 
 // (2, 2)
@@ -748,7 +748,7 @@ func TestInitStop_Unstoppable_TwoWrittenTwoRunning(t *testing.T) {
 	assert.Equal(t, 0, result.exitCode)
 	assert.Empty(t, result.stderr)
 	assert.Contains(t, result.startupLog, "processes")
-	assert.Contains(t, result.startupLog, "did not stop within 120 seconds, so a SIGKILL was sent")
+	assert.Contains(t, result.startupLog, "did not stop within 110 seconds, so a SIGKILL was sent")
 }
 
 func forkKillableSleep(t *testing.T) (pid int, killer func()) {
@@ -935,18 +935,18 @@ func readFromChannel(c <-chan initResult, timeout time.Duration) (result *initRe
 	}
 }
 
-// Runs init 'stop' and asserts that it will time out after 120 seconds.
+// Runs init 'stop' and asserts that it will time out after 110 seconds.
 func runStopAssertTimesOut(t *testing.T) *initResult {
 	clock := time2.NewFakeClock()
 	initChan := runInitWithClock(t, clock, "stop")
 	clock.BlockUntil(2) // wait for timer and ticker to attach
-	clock.Advance(119 * time.Second)
+	clock.Advance(109 * time.Second)
 	result := readFromChannel(initChan, 1*time.Second)
-	require.Nil(t, result, "Expected `stop` to still wait after 119 seconds")
+	require.Nil(t, result, "Expected `stop` to still wait after 109 seconds")
 
 	clock.Advance(1 * time.Second)
 	result2 := readFromChannel(initChan, 1*time.Second)
-	require.NotNil(t, result2, "Expected `stop` to finish after 120 seconds")
+	require.NotNil(t, result2, "Expected `stop` to finish after 110 seconds")
 
 	return result2
 }


### PR DESCRIPTION
## Before this PR

Currently, a java process which is stuck for some reason will never receive SIGKILL because our deployment infra only allows shutdowns to take 2 minutes. If deployment binary then SIGKILL's go-java-launcher, which was still waiting for it's 4 minute timeout to elapse, then underlying java process never actually gets killed properly.

## After this PR

We can't catch the incoming SIGKILL for the parent deployment process, so instead our timeout is slightly shorter (110 seconds), so that we can fire off a SIGKILL to the child java process rather than leaving it as a zombie.

## Possible downsides

- I don't think any WC services can be relying on the 4 minute timeout because WC itself already has a 2 minute timeout!!