### PR TITLE
[improvement] Change default behavior of 'javaHome' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ configType: java
 configVersion: 1
 # REQUIRED - The main class to be run
 mainClass: my.package.Main
-# OPTIONAL - Path to the JRE or environment variable name (e.g. $JAVA_11_HOME). Defaults to the JAVA_HOME environment variable if unset
+# OPTIONAL - Path to the JRE or environment variable name (e.g. $JAVA_11_HOME). Defaults to the JAVA_HOME environment variable if unset,
+#  or if the specified environment variable is not set at runtime.
 javaHome: /opt/palantir/jdk8/Contents/Home
 # REQUIRED - The classpath entries; the final classpath is the ':'-concatenated list in the given order
 classpath:

--- a/changelog/@unreleased/pr-109.yml
+++ b/changelog/@unreleased/pr-109.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: The javaHome option, when set to a variable, now
+    checks to see if the variable is set at runtime. If it is
+    not set, it falls back on $JAVA_HOME.
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/109

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -162,9 +162,8 @@ func getJavaHome(explicitJavaHome string) (string, error) {
                 jh, err := loadEnvVar(explicitJavaHome[1:])
                 if err != nil {
                         return loadEnvVar("JAVA_HOME")
-                } else {
-                        return jh, nil
                 }
+                return jh, nil
 	} else {
                 return explicitJavaHome, nil
         }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -159,14 +159,14 @@ func getJavaHome(explicitJavaHome string) (string, error) {
 		if len(explicitJavaHome) == 1 {
 			return "", fmt.Errorf("javaHome set to just '$' is not allowed, please use a path or an env var name like $JAVA_11_HOME")
 		}
-                jh, err := loadEnvVar(explicitJavaHome[1:])
-                if err != nil {
-                        return loadEnvVar("JAVA_HOME")
-                }
-                return jh, nil
+		jh, err := loadEnvVar(explicitJavaHome[1:])
+		if err != nil {
+			return loadEnvVar("JAVA_HOME")
+		}
+		return jh, nil
 	} else {
-                return explicitJavaHome, nil
-        }
+		return explicitJavaHome, nil
+	}
 }
 
 func loadEnvVar(envVar string) (string, error) {

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -155,17 +155,19 @@ func verifyPathIsSafeForExec(execPath string) (string, error) {
 func getJavaHome(explicitJavaHome string) (string, error) {
 	if explicitJavaHome == "" {
 		return loadEnvVar("JAVA_HOME")
-	}
-
-	if explicitJavaHome[0] == '$' {
+	} else if explicitJavaHome[0] == '$' {
 		if len(explicitJavaHome) == 1 {
 			return "", fmt.Errorf("javaHome set to just '$' is not allowed, please use a path or an env var name like $JAVA_11_HOME")
 		}
-
-		return loadEnvVar(explicitJavaHome[1:])
-	}
-
-	return explicitJavaHome, nil
+                jh, err := loadEnvVar(explicitJavaHome[1:])
+                if err != nil {
+                        return loadEnvVar("JAVA_HOME")
+                } else {
+                        return jh, nil
+                }
+	} else {
+                return explicitJavaHome, nil
+        }
 }
 
 func loadEnvVar(envVar string) (string, error) {

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -49,6 +49,17 @@ func TestGetJavaHome_allowsReadingOtherEnvVar(t *testing.T) {
 	assert.Equal(t, "foo", javaHome)
 }
 
+func TestGetJavaHome_defaultsToJavaHomeWhenUndefined(t *testing.T) {
+	originalJavaHome := os.Getenv("JAVA_HOME")
+	require.NoError(t, os.Setenv("JAVA_HOME", "foo"))
+
+	javaHome, javaHomeErr := getJavaHome("$SOME_VAR")
+	assert.NoError(t, javaHomeErr)
+	assert.Equal(t, "foo", javaHome)
+
+	require.NoError(t, os.Setenv("JAVA_HOME", originalJavaHome))
+}
+
 func TestSetCustomEnvironment(t *testing.T) {
 	originalEnv := make(map[string]string)
 	customEnv := map[string]string{


### PR DESCRIPTION
This option previously meant 'Use $JAVA_HOME' if this option is not set
at all. It now means 'use $JAVA_HOME' if this option is not set OR if
the environment variable it's set to is not defined at runtime.

This is useful in environments where a default JDK is preferred, but
init should not fail should this JDK be absent.