### PR TITLE
Add build outputs for ARM

### DIFF
--- a/changelog/@unreleased/pr-125.v2.yml
+++ b/changelog/@unreleased/pr-125.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Build outputs include arm64
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/125

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -7,6 +7,8 @@ products:
         arch: amd64
       - os: linux
         arch: amd64
+      - os: linux
+        arch: arm64
     dist:
       disters:
         bin:
@@ -25,6 +27,8 @@ products:
         arch: amd64
       - os: linux
         arch: amd64
+      - os: linux
+        arch: arm64
     dist:
       disters:
         bin:


### PR DESCRIPTION
We have some new needs to deploy services on ARM, so we should begin packaging these artifacts.

## Before this PR
Builds for Mac and Linux on amd64.

## After this PR
==COMMIT_MSG==
Build outputs include arm64
==COMMIT_MSG==

## Possible downsides?
Additional storage cost of built artifacts.

