### PR TITLE
rotate startup logs

### DIFF
--- a/changelog/@unreleased/pr-141.v2.yml
+++ b/changelog/@unreleased/pr-141.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Startup logs are rotated. 6 old logs are retained.
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/141

--- a/init/cli/cli.go
+++ b/init/cli/cli.go
@@ -41,8 +41,9 @@ func executeWithLoggers(action func(cli.Context, launchlib.ServiceLoggers) error
 		}
 
 		loggers := &FileLoggers{
-			flags: flags,
-			mode:  outputFileMode,
+			flags:     flags,
+			mode:      outputFileMode,
+			openFiles: make(map[string]*os.File),
 		}
 
 		outputFile, err := loggers.PrimaryLogger()

--- a/init/cli/cli.go
+++ b/init/cli/cli.go
@@ -40,11 +40,7 @@ func executeWithLoggers(action func(cli.Context, launchlib.ServiceLoggers) error
 				ctx, errors.Wrapf(err, "Error trying to make log directory '%s'", logDir), 4)
 		}
 
-		loggers := &FileLoggers{
-			flags:     flags,
-			mode:      outputFileMode,
-			openFiles: make(map[string]*os.File),
-		}
+		loggers := NewFileLoggers(flags, outputFileMode)
 
 		outputFile, err := loggers.PrimaryLogger()
 		if err != nil {

--- a/init/cli/logging.go
+++ b/init/cli/logging.go
@@ -97,11 +97,11 @@ func (f *FileLoggers) OpenFile(path string) (*os.File, error) {
 
 func rotate(path string) {
 	limit := 5
-	os.Remove(path + "." + strconv.Itoa(limit))
+	_ = os.Remove(path + "." + strconv.Itoa(limit))
 	for i := limit; i > 0; i-- {
-		os.Rename(path+"."+strconv.Itoa(i-1), path+"."+strconv.Itoa(i))
+		_ = os.Rename(path+"."+strconv.Itoa(i-1), path+"."+strconv.Itoa(i))
 	}
-	os.Rename(path, path+".0")
+	_ = os.Rename(path, path+".0")
 }
 
 var devNull = launchlib.NoopClosingWriter{Writer: ioutil.Discard}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When a service fails to start, it is automatically started again. A new startup log is written, overwriting the existing one, which makes it impossible to determine why a service failed to start if it crashes early enough in the startup process.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Startup logs are rotated. 6 old logs are retained.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Extra disk space usage.
