### PR TITLE
Autorelease go version upgrades

### DIFF
--- a/.excavator.yml
+++ b/.excavator.yml
@@ -4,6 +4,7 @@ auto-label:
   names:
     versions-props/upgrade-all: [ "merge when ready" ]
     circleci/manage-circleci: [ "merge when ready" ]
+    go/manage-go-version-oss: [ "merge when ready", "autorelease" ]
   tags:
     roomba: [ "merge when ready" ]
     automerge: [ "merge when ready" ]


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR

We want to autorelease excavator PRs that update the GO version ([example](https://github.com/palantir/go-java-launcher/pull/197)) as they frequently contain security patches that we want to provide for downstream consumers.

==COMMIT_MSG==
Autorelease go version upgrades
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

