### PR TITLE
Make linkable headers for launcher yml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ launch scripts which are susceptible to attacks via injection of environment var
 The launcher accepts as configuration two YAML files as follows:
 
 ### launcher-static.yml
+
 ```yaml
 # StaticLauncherConfig - java version
 # REQUIRED - The type of configuration, must be the string "java"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ launch scripts which are susceptible to attacks via injection of environment var
 
 The launcher accepts as configuration two YAML files as follows:
 
+### launcher-static.yml
 ```yaml
 # StaticLauncherConfig - java version
 # REQUIRED - The type of configuration, must be the string "java"
@@ -83,6 +84,8 @@ subProcesses:
       - var/data/tmp
       - var/log
 ```
+
+### launcher-custom.yml
 
 ```yaml
 # CustomLauncherConfig


### PR DESCRIPTION
This way the `launcher-custom.yml` config format can be referred to by deep link: https://github.com/palantir/go-java-launcher#launcher-customyml

## Before this PR
Visiting https://github.com/palantir/go-java-launcher takes a while for a reader to find the config format for `launcher-custom.yml`.

## After this PR
Visiting https://github.com/palantir/go-java-launcher#launcher-customyml takes you directly to the config format.
