### PR TITLE
Fix cpu.shares content parsing

### DIFF
--- a/changelog/@unreleased/pr-321.v2.yml
+++ b/changelog/@unreleased/pr-321.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix cpu.shares content parsing
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/321

--- a/launchlib/processors.go
+++ b/launchlib/processors.go
@@ -67,7 +67,7 @@ func (c CGroupV1ProcessorCounter) ProcessorCount() (uint, error) {
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to read cpu.shares")
 	}
-	cpuShares, err := strconv.Atoi(string(cpuShareBytes))
+	cpuShares, err := strconv.Atoi(strings.TrimSpace(string(cpuShareBytes)))
 	if err != nil {
 		return 0, errors.New("unable to convert cpu.shares value to expected type")
 	}

--- a/launchlib/processors_test.go
+++ b/launchlib/processors_test.go
@@ -88,8 +88,8 @@ var (
 3473 5088 0:435 / /proc/scsi ro,relatime - tmpfs tmpfs ro
 3474 5092 0:436 / /sys/firmware ro,relatime - tmpfs tmpfs ro`)
 
-	lowCPUSharesContent  = []byte(`100`)
-	highCPUSharesContent = []byte(`10000`)
+	lowCPUSharesContent  = []byte("100\n")
+	highCPUSharesContent = []byte("10000\n")
 	badCPUSharesContent  = []byte(``)
 )
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously, we attempted to read the raw content of the cpu.shares value as an integer. However, the actual content of the file has a trailing newline, causing us to fail parsing the value. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix cpu.shares content parsing
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

