### PR TITLE
Refactor cgroup parsing to be less CPU module specific

### DIFF
--- a/launchlib/cgroup.go
+++ b/launchlib/cgroup.go
@@ -1,0 +1,111 @@
+package launchlib
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	selfCGroup    = "/proc/self/cgroup"
+	selfMountinfo = "/proc/self/mountinfo"
+)
+
+type CGroupName string
+
+type CGroupPather interface {
+	Path(name CGroupName) (string, error)
+}
+
+var DefaultCGroupV1Pather = CGroupV1Pather{
+	fs: os.DirFS("/"),
+}
+
+type CGroupV1Pather struct {
+	fs fs.FS
+}
+
+func NewCGroupV1Pather(filesystem fs.FS) CGroupPather {
+	return CGroupV1Pather{fs: filesystem}
+}
+
+// Path implements CGroupPather
+func (c CGroupV1Pather) Path(name CGroupName) (string, error) {
+	selfCGroupFile, err := c.fs.Open(convertToFSPath(selfCGroup))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to open cgroup file")
+	}
+	cgroupModuleRootMountPath, err := c.getCGroupPath(selfCGroupFile, name)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get cgroup information for module %s from cgroup entries", name)
+	}
+
+	selfMountinfoFile, err := c.fs.Open(convertToFSPath(selfMountinfo))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to open mountinfo file")
+	}
+	mountinfo, err := io.ReadAll(selfMountinfoFile)
+	if err != nil {
+		return "", err
+	}
+
+	// iterate over mount points, filtering to entries which contain the path of our subsystem and the name of our subsystem
+	for _, entry := range bytes.Split(mountinfo, []byte("\n")) {
+		fields := bytes.Fields(entry)
+		if len(fields) < 10 {
+			continue
+		}
+
+		rootMount, mount, options := fields[3], fields[4], fields[len(fields)-1]
+
+		if !bytes.Equal(rootMount, []byte(cgroupModuleRootMountPath)) {
+			continue
+		}
+		// options and mount points may contain multiple cgroup types within them, separated by commas (e.g. cpu,cpuacct)
+		for _, option := range bytes.Split(options, []byte(",")) {
+			if bytes.Equal(option, []byte(name)) {
+				mountBases := strings.Split(filepath.Base(string(mount)), ",")
+				if len(mountBases) == 1 {
+					return string(mount), nil
+				}
+				for _, mountBase := range mountBases {
+					if mountBase == string(name) {
+						return filepath.Join(filepath.Dir(string(mount)), mountBase), nil
+					}
+				}
+			}
+		}
+	}
+	return "", errors.Errorf("unable to find cgroup mount path for module %s", name)
+}
+
+func (c CGroupV1Pather) getCGroupPath(r io.Reader, name CGroupName) (string, error) {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		cgroupParts := strings.Split(s.Text(), ":")
+		if len(cgroupParts) < 3 {
+			continue
+		}
+		cgroupNames := cgroupParts[1]
+		for _, subgroup := range strings.Split(cgroupNames, ",") {
+			if subgroup == string(name) {
+				return cgroupParts[2], nil
+			}
+		}
+	}
+	return "", errors.Errorf("unable to find cgroup mount path for module %s in cgroup entries", name)
+}
+
+func convertToFSPath(path string) string {
+	// The io.fs package has some path quirks, the biggest being that it expects to work with unrooted paths, and will
+	// reject any paths with leading slashes as invalid. To deal with this, we have to remove any trailing slashes that
+	// we get back from parsing any
+	// https://pkg.go.dev/io/fs#ValidPath
+	return strings.TrimPrefix(path, "/")
+}

--- a/launchlib/cgroup_test.go
+++ b/launchlib/cgroup_test.go
@@ -1,0 +1,154 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package launchlib_test
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/palantir/go-java-launcher/launchlib"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	CGroupContent = []byte(`12:memory:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+11:blkio:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+10:cpu,cpuacct:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+9:hugetlb:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+8:freezer:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+7:pids:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+6:perf_event:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+5:rdma:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+4:net_cls,net_prio:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+3:cpuset:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+2:devices:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+1:name=systemd:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
+0::/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151`)
+
+	MountInfoContent = []byte(`5087 3462 0:337 / / rw,relatime master:945 - overlay overlay rw,lowerdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/618/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/617/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/616/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/615/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/614/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/fs,upperdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/fs,workdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/work,xino=off
+5088 5087 0:338 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+5089 5087 0:339 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+5090 5089 0:356 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+5091 5089 0:304 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
+5092 5087 0:333 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
+5093 5092 0:433 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
+5094 5093 0:30 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/systemd ro,nosuid,nodev,noexec,relatime master:9 - cgroup cgroup rw,xattr,name=systemd
+5095 5093 0:33 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/devices ro,nosuid,nodev,noexec,relatime master:15 - cgroup cgroup rw,devices
+5096 5093 0:34 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/cpuset ro,nosuid,nodev,noexec,relatime master:16 - cgroup cgroup rw,cpuset
+5097 5093 0:35 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/net_cls,net_prio ro,nosuid,nodev,noexec,relatime master:17 - cgroup cgroup rw,net_cls,net_prio
+5098 5093 0:36 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/rdma ro,nosuid,nodev,noexec,relatime master:18 - cgroup cgroup rw,rdma
+5133 5093 0:37 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/perf_event ro,nosuid,nodev,noexec,relatime master:19 - cgroup cgroup rw,perf_event
+5134 5093 0:38 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/pids ro,nosuid,nodev,noexec,relatime master:20 - cgroup cgroup rw,pids
+5135 5093 0:39 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/freezer ro,nosuid,nodev,noexec,relatime master:21 - cgroup cgroup rw,freezer
+5136 5093 0:40 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/hugetlb ro,nosuid,nodev,noexec,relatime master:22 - cgroup cgroup rw,hugetlb
+5137 5093 0:41 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/cpu,cpuacct ro,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,cpu,cpuacct
+5138 5093 0:42 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/blkio ro,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,blkio
+5139 5093 0:43 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/memory ro,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,memory
+3463 5088 0:338 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
+3464 5088 0:338 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
+3465 5088 0:338 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
+3466 5088 0:338 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
+3467 5088 0:338 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
+3468 5088 0:434 / /proc/acpi ro,relatime - tmpfs tmpfs ro
+3469 5088 0:339 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+3470 5088 0:339 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+3471 5088 0:339 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+3472 5088 0:339 /null /proc/sched_debug rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+3473 5088 0:435 / /proc/scsi ro,relatime - tmpfs tmpfs ro
+3474 5092 0:436 / /sys/firmware ro,relatime - tmpfs tmpfs ro`)
+
+	badMountInfoContent = []byte(`5087 3462 0:337 / / rw,relatime master:945 - overlay overlay rw,lowerdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/618/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/617/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/616/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/615/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/614/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/fs,upperdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/fs,workdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/work,xino=off
+5088 5087 0:338 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+5089 5087 0:339 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+5090 5089 0:356 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+5091 5089 0:304 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
+5092 5087 0:333 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
+5093 5092 0:433 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
+3463 5088 0:338 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
+3464 5088 0:338 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
+3465 5088 0:338 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
+3466 5088 0:338 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
+3467 5088 0:338 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
+3468 5088 0:434 / /proc/acpi ro,relatime - tmpfs tmpfs ro
+3473 5088 0:435 / /proc/scsi ro,relatime - tmpfs tmpfs ro
+3474 5092 0:436 / /sys/firmware ro,relatime - tmpfs tmpfs ro`)
+)
+
+func TestGCroupPather_CGroupV1Pather(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		filesystem    fs.FS
+		cgroupName    string
+		expectedPath  string
+		expectedError error
+	}{
+		{
+			name:          "fails when unable to read self cgroup",
+			filesystem:    fstest.MapFS{},
+			expectedError: errors.New("failed to open cgroup file"),
+		},
+		{
+			name: "fails when unable to read self mountinfo",
+			filesystem: fstest.MapFS{
+				"proc/self/cgroup": &fstest.MapFile{
+					Data: CGroupContent,
+					Mode: fs.ModePerm,
+				},
+			},
+			expectedError: errors.New("failed to open mountinfo file"),
+		},
+		{
+			name: "fails when unable to parse mountinfo for cpu cgroup location",
+			filesystem: fstest.MapFS{
+				"proc/self/cgroup": &fstest.MapFile{
+					Data: CGroupContent,
+				},
+				"proc/self/mountinfo": &fstest.MapFile{
+					Data: badMountInfoContent,
+				},
+			},
+			cgroupName:    "cpu",
+			expectedError: errors.New("unable to find cgroup mount path for module cpu"),
+		},
+		{
+			name: "returns expected path for known cgroup name",
+			filesystem: fstest.MapFS{
+				"proc/self/cgroup": &fstest.MapFile{
+					Data: CGroupContent,
+				},
+				"proc/self/mountinfo": &fstest.MapFile{
+					Data: MountInfoContent,
+				},
+			},
+			cgroupName:   "cpu",
+			expectedPath: "/sys/fs/cgroup/cpu",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pather := launchlib.NewCGroupV1Pather(test.filesystem)
+			processorCount, err := pather.Path(launchlib.CGroupName(test.cgroupName))
+			if test.expectedError != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedError.Error())
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedPath, processorCount)
+		})
+	}
+}

--- a/launchlib/processors_test.go
+++ b/launchlib/processors_test.go
@@ -26,68 +26,6 @@ import (
 )
 
 var (
-	cgroupContent = []byte(`12:memory:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-11:blkio:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-10:cpu,cpuacct:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-9:hugetlb:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-8:freezer:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-7:pids:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-6:perf_event:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-5:rdma:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-4:net_cls,net_prio:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-3:cpuset:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-2:devices:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-1:name=systemd:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-0::/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151`)
-
-	mountInfoContent = []byte(`5087 3462 0:337 / / rw,relatime master:945 - overlay overlay rw,lowerdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/618/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/617/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/616/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/615/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/614/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/fs,upperdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/fs,workdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/work,xino=off
-5088 5087 0:338 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
-5089 5087 0:339 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-5090 5089 0:356 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-5091 5089 0:304 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
-5092 5087 0:333 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
-5093 5092 0:433 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
-5094 5093 0:30 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/systemd ro,nosuid,nodev,noexec,relatime master:9 - cgroup cgroup rw,xattr,name=systemd
-5095 5093 0:33 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/devices ro,nosuid,nodev,noexec,relatime master:15 - cgroup cgroup rw,devices
-5096 5093 0:34 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/cpuset ro,nosuid,nodev,noexec,relatime master:16 - cgroup cgroup rw,cpuset
-5097 5093 0:35 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/net_cls,net_prio ro,nosuid,nodev,noexec,relatime master:17 - cgroup cgroup rw,net_cls,net_prio
-5098 5093 0:36 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/rdma ro,nosuid,nodev,noexec,relatime master:18 - cgroup cgroup rw,rdma
-5133 5093 0:37 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/perf_event ro,nosuid,nodev,noexec,relatime master:19 - cgroup cgroup rw,perf_event
-5134 5093 0:38 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/pids ro,nosuid,nodev,noexec,relatime master:20 - cgroup cgroup rw,pids
-5135 5093 0:39 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/freezer ro,nosuid,nodev,noexec,relatime master:21 - cgroup cgroup rw,freezer
-5136 5093 0:40 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/hugetlb ro,nosuid,nodev,noexec,relatime master:22 - cgroup cgroup rw,hugetlb
-5137 5093 0:41 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/cpu,cpuacct ro,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,cpu,cpuacct
-5138 5093 0:42 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/blkio ro,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,blkio
-5139 5093 0:43 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/memory ro,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,memory
-3463 5088 0:338 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
-3464 5088 0:338 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
-3465 5088 0:338 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
-3466 5088 0:338 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
-3467 5088 0:338 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
-3468 5088 0:434 / /proc/acpi ro,relatime - tmpfs tmpfs ro
-3469 5088 0:339 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-3470 5088 0:339 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-3471 5088 0:339 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-3472 5088 0:339 /null /proc/sched_debug rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-3473 5088 0:435 / /proc/scsi ro,relatime - tmpfs tmpfs ro
-3474 5092 0:436 / /sys/firmware ro,relatime - tmpfs tmpfs ro`)
-
-	badMountInfoContent = []byte(`5087 3462 0:337 / / rw,relatime master:945 - overlay overlay rw,lowerdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/618/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/617/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/616/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/615/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/614/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/fs,upperdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/fs,workdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/work,xino=off
-5088 5087 0:338 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
-5089 5087 0:339 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-5090 5089 0:356 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-5091 5089 0:304 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
-5092 5087 0:333 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
-5093 5092 0:433 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
-3463 5088 0:338 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
-3464 5088 0:338 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
-3465 5088 0:338 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
-3466 5088 0:338 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
-3467 5088 0:338 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
-3468 5088 0:434 / /proc/acpi ro,relatime - tmpfs tmpfs ro
-3473 5088 0:435 / /proc/scsi ro,relatime - tmpfs tmpfs ro
-3474 5092 0:436 / /sys/firmware ro,relatime - tmpfs tmpfs ro`)
-
 	lowCPUSharesContent  = []byte("100\n")
 	highCPUSharesContent = []byte("10000\n")
 	badCPUSharesContent  = []byte(``)
@@ -101,40 +39,13 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 		expectedError          error
 	}{
 		{
-			name:          "fails when unable to read self cgroup",
-			filesystem:    fstest.MapFS{},
-			expectedError: errors.New("failed to open cgroup file"),
-		},
-		{
-			name: "fails when unable to read self mountinfo",
-			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: cgroupContent,
-					Mode: fs.ModePerm,
-				},
-			},
-			expectedError: errors.New("failed to open mountinfo file"),
-		},
-		{
-			name: "fails when unable to parse mountinfo for cpu cgroup location",
-			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: cgroupContent,
-				},
-				"proc/self/mountinfo": &fstest.MapFile{
-					Data: badMountInfoContent,
-				},
-			},
-			expectedError: errors.New("unable to find cpu cgroup mount path"),
-		},
-		{
 			name: "fails when unable to read cpu.shares",
 			filesystem: fstest.MapFS{
 				"proc/self/cgroup": &fstest.MapFile{
-					Data: cgroupContent,
+					Data: CGroupContent,
 				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: mountInfoContent,
+					Data: MountInfoContent,
 				},
 			},
 			expectedError: errors.New("unable to open cpu.shares at expected location"),
@@ -143,10 +54,10 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 			name: "fails when unable to parse cpu.shares",
 			filesystem: fstest.MapFS{
 				"proc/self/cgroup": &fstest.MapFile{
-					Data: cgroupContent,
+					Data: CGroupContent,
 				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: mountInfoContent,
+					Data: MountInfoContent,
 				},
 				"sys/fs/cgroup/cpu/cpu.shares": &fstest.MapFile{
 					Data: badCPUSharesContent,
@@ -158,10 +69,10 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 			name: "returns expected processor count when cpu.shares under 2 cores",
 			filesystem: fstest.MapFS{
 				"proc/self/cgroup": &fstest.MapFile{
-					Data: cgroupContent,
+					Data: CGroupContent,
 				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: mountInfoContent,
+					Data: MountInfoContent,
 				},
 				"sys/fs/cgroup/cpu/cpu.shares": &fstest.MapFile{
 					Data: lowCPUSharesContent,
@@ -173,10 +84,10 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 			name: "returns expected processor count when cpu.shares over 2 cores",
 			filesystem: fstest.MapFS{
 				"proc/self/cgroup": &fstest.MapFile{
-					Data: cgroupContent,
+					Data: CGroupContent,
 				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: mountInfoContent,
+					Data: MountInfoContent,
 				},
 				"sys/fs/cgroup/cpu/cpu.shares": &fstest.MapFile{
 					Data: highCPUSharesContent,


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously, the cgroup parsing code had some bits specific to reading the cpu and cpu.shares information. We're going to need this for reading memory information as well, so should probably break it out into an interface.

