### PR TITLE
Enable active processor count overriding by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,11 @@ All output from `go-java-launcher` itself, and from the launch of all processes 
 By default, when starting a java process inside a container (as indicated by the presence of ``CONTAINER`` env
 variable):
 
+1. `-XX:ActiveProcessorCount` will be set based on the discovered cgroup configurations and host information to a value
+   between 2 and the number of processors reported by the runtime. You can read more about the reasoning behind this
+   [here](https://github.com/palantir/go-java-launcher/issues/313).
 1. Args with prefix``-Xmx|-Xms`` in both static and custom jvm opts will be filtered out.
-2. If neither ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or
+1. If neither ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or
    custom jvm opts, both will be set to ``75.0`` (i.e. ``-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 `` will
    be appended after all the other jvm opts).
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ All output from `go-java-launcher` itself, and from the launch of all processes 
 By default, when starting a java process inside a container (as indicated by the presence of ``CONTAINER`` env
 variable):
 
-1. `-XX:ActiveProcessorCount` will be set based on the discovered cgroup configurations and host information to a value
-   between 2 and the number of processors reported by the runtime. You can read more about the reasoning behind this
-   [here](https://github.com/palantir/go-java-launcher/issues/313).
+1. If `-XX:ActiveProcessorCount` is unset, it will be set based on the discovered cgroup configurations and host
+   information to a value between 2 and the number of processors reported by the runtime. You can read more about the
+   reasoning behind this [here](https://github.com/palantir/go-java-launcher/issues/313).
 1. Args with prefix``-Xmx|-Xms`` in both static and custom jvm opts will be filtered out.
 1. If neither ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or
    custom jvm opts, both will be set to ``75.0`` (i.e. ``-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 `` will

--- a/changelog/@unreleased/pr-329.v2.yml
+++ b/changelog/@unreleased/pr-329.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Enable active processor count overriding by default
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/329

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -119,7 +119,7 @@ func TestMainMethodWithoutCustomConfig(t *testing.T) {
 }
 
 func TestMainMethodContainerWithoutCustomConfig(t *testing.T) {
-	output := testContainerSupportEnabled(t, "foo", "-XX\\:InitialRAMPercentage=75.0 -XX\\:MaxRAMPercentage=75.0")
+	output := testContainerSupportEnabled(t, "foo", "-XX\\:InitialRAMPercentage=75.0 -XX\\:MaxRAMPercentage=75.0 -XX\\:ActiveProcessorCount=2")
 	assert.Regexp(t, `Failed to read custom config file, assuming no custom config: foo`, output)
 }
 

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -52,22 +52,22 @@ func TestMainMethodContainerSupportEnabled(t *testing.T) {
 		{
 			name:            "sets defaults",
 			launcherCustom:  "testdata/launcher-custom.yml",
-			expectedJVMArgs: "-XX\\:InitialRAMPercentage=75.0 -XX\\:MaxRAMPercentage=75.0",
+			expectedJVMArgs: "-XX\\:InitialRAMPercentage=75.0 -XX\\:MaxRAMPercentage=75.0 -XX\\:ActiveProcessorCount=2",
 		},
 		{
 			name:            "does not set defaults if InitialRAMPercentage override is present",
 			launcherCustom:  "testdata/launcher-custom-initial-ram-percentage-override.yml",
-			expectedJVMArgs: "-XX\\:InitialRAMPercentage=79.9",
+			expectedJVMArgs: "-XX\\:InitialRAMPercentage=79.9 -XX\\:ActiveProcessorCount=2",
 		},
 		{
 			name:            "does not set defaults if MaxRAMPercentage override is present",
 			launcherCustom:  "testdata/launcher-custom-max-ram-percentage-override.yml",
-			expectedJVMArgs: "-XX\\:MaxRAMPercentage=79.9",
+			expectedJVMArgs: "-XX\\:MaxRAMPercentage=79.9 -XX\\:ActiveProcessorCount=2",
 		},
 		{
 			name:            "does not set defaults if InitialRAMPercentage and MaxRAMPercentage overrides are present",
 			launcherCustom:  "testdata/launcher-custom-initial-and-max-ram-percentage-override.yml",
-			expectedJVMArgs: "-XX\\:InitialRAMPercentage=79.9 -XX\\:MaxRAMPercentage=80.9",
+			expectedJVMArgs: "-XX\\:InitialRAMPercentage=79.9 -XX\\:MaxRAMPercentage=80.9 -XX\\:ActiveProcessorCount=2",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -71,9 +71,7 @@ type CustomLauncherConfig struct {
 	DisableContainerSupport bool                       `yaml:"dangerousDisableContainerSupport"`
 }
 
-type ExperimentalLauncherConfig struct {
-	OverrideActiveProcessorCount bool `yaml:"overrideActiveProcessorCount"`
-}
+type ExperimentalLauncherConfig struct{}
 
 type PrimaryCustomLauncherConfig struct {
 	VersionedConfig      `yaml:",inline"`

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -280,9 +280,7 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 	if isEnvVarSet("CONTAINER") && !customConfig.DisableContainerSupport && !hasMaxRAMOverride(combinedJvmOpts) {
 		_, _ = fmt.Fprintln(logger, "Container support enabled")
 		combinedJvmOpts = filterHeapSizeArgs(combinedJvmOpts)
-		if customConfig.Experimental.OverrideActiveProcessorCount {
-			combinedJvmOpts = ensureActiveProcessorCount(combinedJvmOpts, logger)
-		}
+		combinedJvmOpts = ensureActiveProcessorCount(combinedJvmOpts, logger)
 		return combinedJvmOpts
 	}
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable active processor count overriding by default
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

