### PR TITLE
Add the `containerV2` flag to compute initial heap percentage using processor count, and disable setting the `ActiveProcessorCount` JVM option

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,11 @@ percentage of ``MaxRAM`` value, e.g. ``max-heap-size = MaxRAM * MaxRamPercentage
 If the experimental flag `containerV2` is set:
 1. The `-XX:ActiveProcessorCount` is unset, it will remain unset.
 1. Args with prefix``-Xmx|-Xms`` in both static and custom jvm opts will be filtered out. If neither 
- ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or custom jvm opts,
- ``-Xmx|-Xms`` will both be set to be 75% of the heap size minus 3mb per processor, with a minimum value of 50% of the 
-  heap.
-1. If neither ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or
-   custom jvm opts, both will be set to ``75.0`` (i.e. ``-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 `` will
-   be appended after all the other jvm opts).
+ ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or custom jvm opts:
+    - if we can obtain the cgroups memory limit ``-Xmx|-Xms`` will both be set to be 75% of the cgroups memory limit 
+     minus 3mb per processor, with a minimum value of 50% of the heap.
+    - if we cannot obtain the cgroups memory limit, both RAM percentage values will be set to ``75.0`` (i.e. 
+    ``-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 `` will be appended after all the other jvm opts)
 
 ### Overriding default values
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ All output from `go-java-launcher` itself, and from the launch of all processes 
 
 ## Java heap and container support
 
-By default, when starting a java process inside a container (as indicated by the presence of ``CONTAINER`` env
+By _default_, when starting a java process inside a container (as indicated by the presence of ``CONTAINER`` env
 variable):
 
 1. If `-XX:ActiveProcessorCount` is unset, it will be set based on the discovered cgroup configurations and host
@@ -161,6 +161,16 @@ variable):
 
 This will cause the JVM 11+ to discover the ``MaxRAM`` value using Linux cgroups, and calculate the heap sizes as the specified
 percentage of ``MaxRAM`` value, e.g. ``max-heap-size = MaxRAM * MaxRamPercentage``.
+
+If the experimental flag `experimentalContainerV2` is set:
+1. The `-XX:ActiveProcessorCount` is unset, it will remain unset.
+1. Args with prefix``-Xmx|-Xms`` in both static and custom jvm opts will be filtered out. If neither 
+ ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or custom jvm opts,
+ ``-Xmx|-Xms`` will both be set to be 75% of the heap size minus 3mb per processor, with a minimum value of 50% of the 
+  heap.
+1. If neither ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or
+   custom jvm opts, both will be set to ``75.0`` (i.e. ``-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 `` will
+   be appended after all the other jvm opts).
 
 ### Overriding default values
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ variable):
 This will cause the JVM 11+ to discover the ``MaxRAM`` value using Linux cgroups, and calculate the heap sizes as the specified
 percentage of ``MaxRAM`` value, e.g. ``max-heap-size = MaxRAM * MaxRamPercentage``.
 
-If the experimental flag `experimentalContainerV2` is set:
+If the experimental flag `containerV2` is set:
 1. The `-XX:ActiveProcessorCount` is unset, it will remain unset.
 1. Args with prefix``-Xmx|-Xms`` in both static and custom jvm opts will be filtered out. If neither 
  ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or custom jvm opts,

--- a/changelog/@unreleased/pr-361.v2.yml
+++ b/changelog/@unreleased/pr-361.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: When the experimental UseProcessorAwareInitialHeapSize is set, 1) compute
+    the heap percentage as 75% of the heap minus 3mb per processor, with a minimum
+    value of 50%, and 2) don't set the -XX:ActiveProcessorCount JVM option.
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/361

--- a/changelog/@unreleased/pr-361.v2.yml
+++ b/changelog/@unreleased/pr-361.v2.yml
@@ -1,7 +1,7 @@
 type: improvement
 improvement:
-  description: When the experimental `experimentalContainerV2` is set, 1) compute
-    the heap percentage as 75% of the heap minus 3mb per processor, with a minimum
-    value of 50%, and 2) don't set the -XX:ActiveProcessorCount JVM option.
+  description: When the experimental `containerV2` is set, 1) compute the heap percentage
+    as 75% of the heap minus 3mb per processor, with a minimum value of 50%, and 2)
+    don't set the -XX:ActiveProcessorCount JVM option.
   links:
   - https://github.com/palantir/go-java-launcher/pull/361

--- a/changelog/@unreleased/pr-361.v2.yml
+++ b/changelog/@unreleased/pr-361.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
-  description: When the experimental UseProcessorAwareInitialHeapSize is set, 1) compute
+  description: When the experimental `experimentalContainerV2` is set, 1) compute
     the heap percentage as 75% of the heap minus 3mb per processor, with a minimum
     value of 50%, and 2) don't set the -XX:ActiveProcessorCount JVM option.
   links:

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -71,25 +71,25 @@ func TestMainMethodContainerSupportEnabled(t *testing.T) {
 			expectedJVMArgs: "-XX\\:InitialRAMPercentage=79.9 -XX\\:MaxRAMPercentage=80.9 -XX\\:ActiveProcessorCount=2",
 		},
 		{
-			name:               "using experimentalContainerV2 sets Xms and Xmx and does not set ActiveProcessorCount",
+			name:               "using containerV2 sets Xms and Xmx and does not set ActiveProcessorCount",
 			launcherCustom:     "testdata/launcher-custom-experimental-container-v2.yml",
 			expectedJVMArgs:    "",
 			expectedJVMArgKeys: []string{"-Xmx", "-Xms"},
 		},
 		{
-			name: "using experimentalContainerV2 with InitialRAMPercentage does not set Xms, Xmx, or " +
+			name: "using containerV2 with InitialRAMPercentage does not set Xms, Xmx, or " +
 				"ActiveProcessorCount",
 			launcherCustom:  "testdata/launcher-custom-experimental-container-v2-with-initial-ram-percentage.yml",
 			expectedJVMArgs: "-XX\\:InitialRAMPercentage=70.0",
 		},
 		{
-			name: "using experimentalContainerV2 with MaxRAMPercentage does not set Xms, Xmx, or " +
+			name: "using containerV2 with MaxRAMPercentage does not set Xms, Xmx, or " +
 				"ActiveProcessorCount",
 			launcherCustom:  "testdata/launcher-custom-experimental-container-v2-with-max-ram-percentage.yml",
 			expectedJVMArgs: "-XX\\:MaxRAMPercentage=70.0",
 		},
 		{
-			name:               "using experimentalContainerV2 does not use user-provided Xms or Xmx",
+			name:               "using containerV2 does not use user-provided Xms or Xmx",
 			launcherCustom:     "testdata/launcher-custom-experimental-container-v2.yml",
 			expectedJVMArgs:    "",
 			expectedJVMArgKeys: []string{"-Xmx", "-Xms"},

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -220,9 +220,9 @@ func TestComputeJVMHeapSize(t *testing.T) {
 		{
 			name:              "computes 75% of heap minus 3mb per processor",
 			numHostProcessors: 1,
-			memoryLimit:       12 * launchlib.BytesInMebibyte,
-			// 75% of heap - 3mb*processors = 6mb
-			expectedMaxHeapSize: 6 * launchlib.BytesInMebibyte,
+			memoryLimit:       16 * launchlib.BytesInMebibyte,
+			// 75% of heap - 3mb*processors = 9mb
+			expectedMaxHeapSize: 9 * launchlib.BytesInMebibyte,
 		},
 		{
 			name:              "multiple processors",

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -69,6 +69,11 @@ func TestMainMethodContainerSupportEnabled(t *testing.T) {
 			launcherCustom:  "testdata/launcher-custom-initial-and-max-ram-percentage-override.yml",
 			expectedJVMArgs: "-XX\\:InitialRAMPercentage=79.9 -XX\\:MaxRAMPercentage=80.9 -XX\\:ActiveProcessorCount=2",
 		},
+		{
+			name:            "does not set defaults if InitialRAMPercentage and MaxRAMPercentage overrides are present",
+			launcherCustom:  "testdata/launcher-custom-experimental-container-v2.yml",
+			expectedJVMArgs: "",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			testContainerSupportEnabled(t, tc.launcherCustom, tc.expectedJVMArgs)

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -70,9 +70,26 @@ func TestMainMethodContainerSupportEnabled(t *testing.T) {
 			expectedJVMArgs: "-XX\\:InitialRAMPercentage=79.9 -XX\\:MaxRAMPercentage=80.9 -XX\\:ActiveProcessorCount=2",
 		},
 		{
-			name:            "does not set defaults if InitialRAMPercentage and MaxRAMPercentage overrides are present",
+			name:            "using experimentalContainerV2 sets Xms and Xmx and does not set ActiveProcessorCount",
 			launcherCustom:  "testdata/launcher-custom-experimental-container-v2.yml",
-			expectedJVMArgs: "",
+			expectedJVMArgs: "-Xms3107979264 -Xmx3107979264",
+		},
+		{
+			name: "using experimentalContainerV2 with InitialRAMPercentage does not set Xms, Xmx, or " +
+				"ActiveProcessorCount",
+			launcherCustom:  "testdata/launcher-custom-experimental-container-v2-with-initial-ram-percentage.yml",
+			expectedJVMArgs: "-XX\\\\:InitialRAMPercentage=70.0",
+		},
+		{
+			name: "using experimentalContainerV2 with MaxRAMPercentage does not set Xms, Xmx, or " +
+				"ActiveProcessorCount",
+			launcherCustom:  "testdata/launcher-custom-experimental-container-v2-with-max-ram-percentage.yml",
+			expectedJVMArgs: "-XX\\\\:MaxRAMPercentage=70.0",
+		},
+		{
+			name:            "using experimentalContainerV2 does not use user-provided Xms or Xmx",
+			launcherCustom:  "testdata/launcher-custom-experimental-container-v2.yml",
+			expectedJVMArgs: "-Xms3107979264 -Xmx3107979264",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/integration_test/testdata/launcher-custom-experimental-container-v2-with-initial-ram-percentage.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2-with-initial-ram-percentage.yml
@@ -3,4 +3,4 @@ configVersion: 1
 jvmOpts:
   - '-XX:InitialRAMPercentage=70.0'
 experimental:
-  experimentalContainerV2: true
+  containerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-container-v2-with-initial-ram-percentage.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2-with-initial-ram-percentage.yml
@@ -1,0 +1,6 @@
+configType: java
+configVersion: 1
+jvmOpts:
+  - '-XX:InitialRAMPercentage=70.0'
+experimental:
+  experimentalContainerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-container-v2-with-max-ram-percentage.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2-with-max-ram-percentage.yml
@@ -3,4 +3,4 @@ configVersion: 1
 jvmOpts:
   - '-XX:MaxRAMPercentage=70.0'
 experimental:
-  experimentalContainerV2: true
+  containerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-container-v2-with-max-ram-percentage.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2-with-max-ram-percentage.yml
@@ -1,0 +1,6 @@
+configType: java
+configVersion: 1
+jvmOpts:
+  - '-XX:MaxRAMPercentage=70.0'
+experimental:
+  experimentalContainerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-container-v2-with-xms-and-xmx.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2-with-xms-and-xmx.yml
@@ -1,0 +1,7 @@
+configType: java
+configVersion: 1
+jvmOpts:
+  - '-Xms1g'
+  - '-Xmx1g'
+experimental:
+  experimentalContainerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-container-v2-with-xms-and-xmx.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2-with-xms-and-xmx.yml
@@ -4,4 +4,4 @@ jvmOpts:
   - '-Xms1g'
   - '-Xmx1g'
 experimental:
-  experimentalContainerV2: true
+  containerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-container-v2.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2.yml
@@ -1,0 +1,5 @@
+configType: java
+configVersion: 1
+jvmOpts: {}
+experimental:
+  experimentalContainerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-container-v2.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2.yml
@@ -2,4 +2,4 @@ configType: java
 configVersion: 1
 jvmOpts: []
 experimental:
-  experimentalContainerV2: true
+  containerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-container-v2.yml
+++ b/integration_test/testdata/launcher-custom-experimental-container-v2.yml
@@ -1,5 +1,5 @@
 configType: java
 configVersion: 1
-jvmOpts: {}
+jvmOpts: []
 experimental:
   experimentalContainerV2: true

--- a/integration_test/testdata/launcher-custom-experimental-processor-aware-heap-pct-flag.yml
+++ b/integration_test/testdata/launcher-custom-experimental-processor-aware-heap-pct-flag.yml
@@ -3,4 +3,4 @@ configVersion: 1
 jvmOpts:
   - '-Xmx1g'
 experimental:
-  useProcessorAwareInitialHeapPercentage: true
+  useProcessorAwareInitialHeapSize: true

--- a/integration_test/testdata/launcher-custom-experimental-processor-aware-heap-pct-flag.yml
+++ b/integration_test/testdata/launcher-custom-experimental-processor-aware-heap-pct-flag.yml
@@ -1,6 +1,0 @@
-configType: java
-configVersion: 1
-jvmOpts:
-  - '-Xmx1g'
-experimental:
-  useProcessorAwareInitialHeapSize: true

--- a/integration_test/testdata/launcher-custom-experimental-processor-aware-heap-pct-flag.yml
+++ b/integration_test/testdata/launcher-custom-experimental-processor-aware-heap-pct-flag.yml
@@ -3,4 +3,4 @@ configVersion: 1
 jvmOpts:
   - '-Xmx1g'
 experimental:
-  overrideActiveProcessorCount: true
+  useProcessorAwareInitialHeapPercentage: true

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -72,8 +72,7 @@ type CustomLauncherConfig struct {
 }
 
 type ExperimentalLauncherConfig struct {
-	// Also disables setting the active processor count JVM argument.
-	UseProcessorAwareInitialHeapSize bool `yaml:"useProcessorAwareInitialHeapSize"`
+	ExperimentalContainerV2 bool `yaml:"experimentalContainerV2"`
 }
 
 type PrimaryCustomLauncherConfig struct {

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -71,7 +71,10 @@ type CustomLauncherConfig struct {
 	DisableContainerSupport bool                       `yaml:"dangerousDisableContainerSupport"`
 }
 
-type ExperimentalLauncherConfig struct{}
+type ExperimentalLauncherConfig struct {
+	// Also disables setting the active processor count JVM argument.
+	UseProcessorAwareInitialHeapPercentage bool `yaml:"useProcessorAwareInitialHeapPercentage"`
+}
 
 type PrimaryCustomLauncherConfig struct {
 	VersionedConfig      `yaml:",inline"`

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -73,7 +73,7 @@ type CustomLauncherConfig struct {
 
 type ExperimentalLauncherConfig struct {
 	// Also disables setting the active processor count JVM argument.
-	UseProcessorAwareInitialHeapPercentage bool `yaml:"useProcessorAwareInitialHeapPercentage"`
+	UseProcessorAwareInitialHeapSize bool `yaml:"useProcessorAwareInitialHeapSize"`
 }
 
 type PrimaryCustomLauncherConfig struct {

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -72,7 +72,7 @@ type CustomLauncherConfig struct {
 }
 
 type ExperimentalLauncherConfig struct {
-	ExperimentalContainerV2 bool `yaml:"experimentalContainerV2"`
+	ContainerV2 bool `yaml:"containerV2"`
 }
 
 type PrimaryCustomLauncherConfig struct {

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -411,6 +411,6 @@ func computeJVMHeapSizeInBytes() (uint64, error) {
 	}
 	var heapLimit = float64(cgroupMemoryLimitInBytes)
 	var processorAdjustment = 3 * BytesInMebibyte * float64(cgroupProcessorCount)
-	var computedHeapSize = max(0.5*heapLimit, (0.75*heapLimit-processorAdjustment)/heapLimit)
+	var computedHeapSize = max(0.5*heapLimit, 0.75*heapLimit-processorAdjustment)
 	return uint64(computedHeapSize), nil
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -316,8 +316,8 @@ func filterHeapSizeArgs(customConfig *CustomLauncherConfig, args []string) []str
 		if err != nil {
 			initialHeapPercentage = 0.75
 		}
-		filtered = append(filtered, fmt.Sprintf("-XX:InitialRAMPercentage=%f", initialHeapPercentage))
-		filtered = append(filtered, fmt.Sprintf("-XX:MaxRAMPercentage=%f", initialHeapPercentage))
+		filtered = append(filtered, fmt.Sprintf("-XX:InitialRAMPercentage=%.2f", initialHeapPercentage))
+		filtered = append(filtered, fmt.Sprintf("-XX:MaxRAMPercentage=%.2f", initialHeapPercentage))
 	}
 	return filtered
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -316,8 +316,8 @@ func filterHeapSizeArgs(customConfig *CustomLauncherConfig, args []string) []str
 		if err != nil {
 			initialHeapPercentage = 75.0
 		}
-		filtered = append(filtered, fmt.Sprintf("-XX:InitialRAMPercentage=%.2f", initialHeapPercentage))
-		filtered = append(filtered, fmt.Sprintf("-XX:MaxRAMPercentage=%.2f", initialHeapPercentage))
+		filtered = append(filtered, fmt.Sprintf("-XX:InitialRAMPercentage=%.1f", initialHeapPercentage))
+		filtered = append(filtered, fmt.Sprintf("-XX:MaxRAMPercentage=%.1f", initialHeapPercentage))
 	}
 	return filtered
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -101,10 +101,7 @@ func compileCmdFromConfig(
 		combinedJvmOpts = append(combinedJvmOpts, staticConfig.JavaConfig.JvmOpts...)
 		combinedJvmOpts = append(combinedJvmOpts, customConfig.JvmOpts...)
 
-		jvmOpts, err := createJvmOpts(combinedJvmOpts, customConfig, logger)
-		if err != nil {
-			return nil, err
-		}
+		jvmOpts := createJvmOpts(combinedJvmOpts, customConfig, logger)
 
 		executable, executableErr = verifyPathIsSafeForExec(path.Join(javaHome, "/bin/java"))
 		if executableErr != nil {
@@ -281,7 +278,7 @@ func delim(str string) string {
 	return fmt.Sprintf("%s%s%s", TemplateDelimsOpen, str, TemplateDelimsClose)
 }
 
-func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig, logger io.WriteCloser) ([]string, error) {
+func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig, logger io.WriteCloser) []string {
 	if isEnvVarSet("CONTAINER") && !customConfig.DisableContainerSupport && !hasMaxRAMOverride(combinedJvmOpts) {
 		_, _ = fmt.Fprintln(logger, "Container support enabled")
 		if customConfig.Experimental.ContainerV2 {
@@ -298,7 +295,7 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 			combinedJvmOpts = filterHeapSizeArgs(combinedJvmOpts)
 			combinedJvmOpts = ensureActiveProcessorCount(combinedJvmOpts, logger)
 		}
-		return combinedJvmOpts, nil
+		return combinedJvmOpts
 	}
 
 	if isEnvVarSet("CONTAINER") {
@@ -309,7 +306,7 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 		}
 	}
 
-	return combinedJvmOpts, nil
+	return combinedJvmOpts
 }
 
 func filterHeapSizeArgs(args []string) []string {

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -296,8 +296,8 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 			}
 		} else {
 			combinedJvmOpts = filterHeapSizeArgs(combinedJvmOpts)
+			combinedJvmOpts = ensureActiveProcessorCount(combinedJvmOpts, logger)
 		}
-		combinedJvmOpts = ensureActiveProcessorCount(customConfig, combinedJvmOpts, logger)
 		return combinedJvmOpts, nil
 	}
 
@@ -362,7 +362,7 @@ func filterHeapSizeArgsV2(args []string) ([]string, error) {
 	return filtered, nil
 }
 
-func ensureActiveProcessorCount(customConfig *CustomLauncherConfig, args []string, logger io.Writer) []string {
+func ensureActiveProcessorCount(args []string, logger io.Writer) []string {
 	filtered := make([]string, 0, len(args)+1)
 
 	var hasActiveProcessorCount bool
@@ -373,7 +373,7 @@ func ensureActiveProcessorCount(customConfig *CustomLauncherConfig, args []strin
 		filtered = append(filtered, arg)
 	}
 
-	if !hasActiveProcessorCount && !customConfig.Experimental.ContainerV2 {
+	if !hasActiveProcessorCount {
 		processorCountArg, err := getActiveProcessorCountArg(logger)
 		if err == nil {
 			filtered = append(filtered, processorCountArg)

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -314,7 +314,7 @@ func filterHeapSizeArgs(customConfig *CustomLauncherConfig, args []string) []str
 	if !hasInitialRAMPercentage && !hasMaxRAMPercentage {
 		initialHeapPercentage, err := computeInitialHeapPercentage(customConfig)
 		if err != nil {
-			initialHeapPercentage = 0.75
+			initialHeapPercentage = 75.0
 		}
 		filtered = append(filtered, fmt.Sprintf("-XX:InitialRAMPercentage=%.2f", initialHeapPercentage))
 		filtered = append(filtered, fmt.Sprintf("-XX:MaxRAMPercentage=%.2f", initialHeapPercentage))
@@ -386,7 +386,7 @@ func isInitialRAMPercentage(arg string) bool {
 // heap minus 3mb per processor, with a minimum value of 50%.
 func computeInitialHeapPercentage(customConfig *CustomLauncherConfig) (float64, error) {
 	if !customConfig.Experimental.UseProcessorAwareInitialHeapPercentage {
-		return 0.75, nil
+		return 75.0, nil
 	}
 
 	cgroupProcessorCount, err := DefaultCGroupV1ProcessorCounter.ProcessorCount()
@@ -400,5 +400,5 @@ func computeInitialHeapPercentage(customConfig *CustomLauncherConfig) (float64, 
 	var heapLimit = float64(cgroupMemoryLimitInBytes)
 	var processorAdjustment = 3 * BytesInMebibyte * float64(cgroupProcessorCount)
 
-	return max(0.5, (0.75*heapLimit-processorAdjustment)/heapLimit), nil
+	return max(50.0, (0.75*heapLimit-processorAdjustment)/heapLimit*100.0), nil
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -289,7 +289,7 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 			if err != nil {
 				// When we fail to get the memory limit from the cgroups files, fallback to using percentage-based heap
 				// sizing. While this method doesn't take into account the per-processor memory offset, it is supported
-				// by all Java platforms.
+				// by all platforms using Java.
 				combinedJvmOpts = filterHeapSizeArgs(combinedJvmOpts)
 			} else {
 				combinedJvmOpts = jvmOptsWithUpdatedHeapSizeArgs

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -333,7 +333,7 @@ func ensureActiveProcessorCount(customConfig *CustomLauncherConfig, args []strin
 		filtered = append(filtered, arg)
 	}
 
-	if !hasActiveProcessorCount && !customConfig.Experimental.UseProcessorAwareInitialHeapPercentage {
+	if !hasActiveProcessorCount && !customConfig.Experimental.UseProcessorAwareInitialHeapSize {
 		processorCountArg, err := getActiveProcessorCountArg(logger)
 		if err == nil {
 			filtered = append(filtered, processorCountArg)
@@ -382,10 +382,10 @@ func isInitialRAMPercentage(arg string) bool {
 	return strings.HasPrefix(arg, "-XX:InitialRAMPercentage=")
 }
 
-// If the experimental `UseProcessorAwareInitialHeapPercentage` is enabled, compute the heap percentage as 75% of the
+// If the experimental `UseProcessorAwareInitialHeapSize` is set, compute the heap percentage as 75% of the
 // heap minus 3mb per processor, with a minimum value of 50%.
 func computeInitialHeapPercentage(customConfig *CustomLauncherConfig) (float64, error) {
-	if !customConfig.Experimental.UseProcessorAwareInitialHeapPercentage {
+	if !customConfig.Experimental.UseProcessorAwareInitialHeapSize {
 		return 75.0, nil
 	}
 

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -382,6 +382,8 @@ func isInitialRAMPercentage(arg string) bool {
 	return strings.HasPrefix(arg, "-XX:InitialRAMPercentage=")
 }
 
+// If the experimental `UseProcessorAwareInitialHeapPercentage` is enabled, compute the heap percentage as 75% of the
+// heap minus 3mb per processor, with a minimum value of 50%.
 func computeInitialHeapPercentage(customConfig *CustomLauncherConfig) (float64, error) {
 	if !customConfig.Experimental.UseProcessorAwareInitialHeapPercentage {
 		return 0.75, nil
@@ -396,7 +398,7 @@ func computeInitialHeapPercentage(customConfig *CustomLauncherConfig) (float64, 
 		return 0, errors.Wrap(err, "failed to get cgroup memory limit")
 	}
 	var heapLimit = float64(cgroupMemoryLimitInBytes)
-	var processorOffset = 3 * BytesInMebibyte * float64(cgroupProcessorCount)
+	var processorAdjustment = 3 * BytesInMebibyte * float64(cgroupProcessorCount)
 
-	return max(0.5, (0.75*heapLimit-processorOffset)/heapLimit), nil
+	return max(0.5, (0.75*heapLimit-processorAdjustment)/heapLimit), nil
 }

--- a/launchlib/memory.go
+++ b/launchlib/memory.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package launchlib
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	memGroupName = "memory"
+	memLimitName = "memory.limit_in_bytes"
+)
+
+type MemoryLimit interface {
+	MemoryLimitInBytes() (uint64, error)
+}
+
+var DefaultMemoryLimit = NewCGroupMemoryLimit(os.DirFS("/"))
+
+type CGroupMemoryLimit struct {
+	pather CGroupPather
+	fs     fs.FS
+}
+
+func NewCGroupMemoryLimit(filesystem fs.FS) MemoryLimit {
+	return CGroupMemoryLimit{
+		pather: NewCGroupV1Pather(filesystem),
+		fs:     filesystem,
+	}
+}
+
+func (c CGroupMemoryLimit) MemoryLimitInBytes() (uint64, error) {
+	memoryCGroupPath, err := c.pather.Path(memGroupName)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get memory cgroup path")
+	}
+
+	memLimitFilepath := filepath.Join(memoryCGroupPath, memLimitName)
+	memLimitFile, err := c.fs.Open(convertToFSPath(memLimitFilepath))
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to open memory.limit_in_bytes at expected location: %s", memLimitFilepath)
+	}
+	memLimitBytes, err := io.ReadAll(memLimitFile)
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to read memory.limit_in_bytes")
+	}
+	memLimit, err := strconv.Atoi(strings.TrimSpace(string(memLimitBytes)))
+	if err != nil {
+		return 0, errors.New("unable to convert memory.limit_in_bytes value to expected type")
+	}
+	return uint64(memLimit), nil
+}

--- a/launchlib/memory_test.go
+++ b/launchlib/memory_test.go
@@ -1,0 +1,95 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package launchlib_test
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/palantir/go-java-launcher/launchlib"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	memoryLimitContent    = []byte("2147483648\n")
+	badMemoryLimitContent = []byte(``)
+)
+
+func TestMemoryLimit_DefaultMemoryLimit(t *testing.T) {
+	for _, test := range []struct {
+		name                string
+		filesystem          fs.FS
+		expectedMemoryLimit uint64
+		expectedError       error
+	}{
+		{
+			name: "fails when unable to read memory.limit_in_bytes",
+			filesystem: fstest.MapFS{
+				"proc/self/cgroup": &fstest.MapFile{
+					Data: CGroupContent,
+				},
+				"proc/self/mountinfo": &fstest.MapFile{
+					Data: MountInfoContent,
+				},
+			},
+			expectedError: errors.New("unable to open memory.limit_in_bytes at expected location"),
+		},
+		{
+			name: "fails when unable to parse memory.limit_in_bytes",
+			filesystem: fstest.MapFS{
+				"proc/self/cgroup": &fstest.MapFile{
+					Data: CGroupContent,
+				},
+				"proc/self/mountinfo": &fstest.MapFile{
+					Data: MountInfoContent,
+				},
+				"sys/fs/cgroup/memory/memory.limit_in_bytes": &fstest.MapFile{
+					Data: badMemoryLimitContent,
+				},
+			},
+			expectedError: errors.New("unable to convert memory.limit_in_bytes value to expected type"),
+		},
+		{
+			name: "returns expected RAM percentage when memory.limit_in_bytes under 2 GiB",
+			filesystem: fstest.MapFS{
+				"proc/self/cgroup": &fstest.MapFile{
+					Data: CGroupContent,
+				},
+				"proc/self/mountinfo": &fstest.MapFile{
+					Data: MountInfoContent,
+				},
+				"sys/fs/cgroup/memory/memory.limit_in_bytes": &fstest.MapFile{
+					Data: memoryLimitContent,
+				},
+			},
+			expectedMemoryLimit: 1 << 31,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			limit := launchlib.NewCGroupMemoryLimit(test.filesystem)
+			memoryLimit, err := limit.MemoryLimitInBytes()
+			if test.expectedError != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedError.Error())
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedMemoryLimit, memoryLimit)
+		})
+	}
+}


### PR DESCRIPTION
## Before this PR
This is part of a larger effort in improving stability of Java services in Rubix.

### `-XX:ActiveProcessorCount`
k8s resource requests provide a minimum bound on resource usage. The `-XX:ActiveProcessorCount` JVM option acts as an upper bound on resource usage in several internal JDK features (e.g. GC threads, compiler threads). We currently set the active processor count based on resource requests. This has led to unpredictable performance under load.

### Setting initial heap size to be aware of the number of processors
From the above change, we're no longer limiting the number of processors available to the JVM. In the past, when we've removed limits on the number of processors (due to [JDK-8281181](https://bugs.openjdk.org/browse/JDK-8281181) being released in a critical patch update), we've encountered several OOM exceptions. This PR allocates 3mb per processor, by removing that much from the heap size. The rough 3mb figure was obtained by observation (cc: @carterkozak).

## After this PR
==COMMIT_MSG==
When the experimental `containerV2` is set, 1) compute the heap percentage as 75% of the heap minus 3mb per processor, with a minimum value of 50%, and 2) don't set the `-XX:ActiveProcessorCount` JVM option.
==COMMIT_MSG==

## Possible downsides?
This change will potentially waste available memory for services which would benefit from larger heap sizes. Also, the heap size heuristic is simple; a more sophisticated solution would allow for better heap utilization (see #323). 