### PR TITLE
 When the `memory.limit_in_bytes` value is > 1TB, fallback to using 75% {`Initial`/`Max`}`RAMPercentage` values

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,9 @@ percentage of ``MaxRAM`` value, e.g. ``max-heap-size = MaxRAM * MaxRamPercentage
 If the experimental flag `containerV2` is set:
 1. The `-XX:ActiveProcessorCount` is unset, it will remain unset.
 1. Args with prefix``-Xmx|-Xms`` in both static and custom jvm opts will be filtered out. If neither 
- ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or custom jvm opts:
-    - if we can obtain the cgroups memory limit, and the limit is under 1TB, ``-Xmx|-Xms`` will both be set to be 75% of
-      the cgroups memory limit minus 3mb per processor, with a minimum value of 50% of the heap.
-    - if we cannot obtain the cgroups memory limit, both RAM percentage values will be set to ``75.0`` (i.e. 
-    ``-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 `` will be appended after all the other jvm opts)
+ ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or custom jvm opts 
+ ``-Xmx|-Xms`` will both be set to be 75% of the cgroups memory limit minus 3mb per processor, with a minimum value of 
+  50% of the heap.
 
 ### Overriding default values
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ If the experimental flag `containerV2` is set:
 1. The `-XX:ActiveProcessorCount` is unset, it will remain unset.
 1. Args with prefix``-Xmx|-Xms`` in both static and custom jvm opts will be filtered out. If neither 
  ``-XX:MaxRAMPercentage=`` nor ``-XX:InitialRAMPercentage=`` prefixes are present in either static or custom jvm opts:
-    - if we can obtain the cgroups memory limit ``-Xmx|-Xms`` will both be set to be 75% of the cgroups memory limit 
-     minus 3mb per processor, with a minimum value of 50% of the heap.
+    - if we can obtain the cgroups memory limit, and the limit is under 1TB, ``-Xmx|-Xms`` will both be set to be 75% of
+      the cgroups memory limit minus 3mb per processor, with a minimum value of 50% of the heap.
     - if we cannot obtain the cgroups memory limit, both RAM percentage values will be set to ``75.0`` (i.e. 
     ``-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 `` will be appended after all the other jvm opts)
 

--- a/changelog/@unreleased/pr-362.v2.yml
+++ b/changelog/@unreleased/pr-362.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: When the `memory.limit_in_bytes` value is > 1TB, fallback to using
+    75% {`Initial`/`Max`}`RAMPercentage` values
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/362

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -352,6 +352,9 @@ func filterHeapSizeArgsV2(args []string) ([]string, error) {
 		if err != nil {
 			return filtered, errors.Wrap(err, "failed to get cgroup memory limit")
 		}
+		if cgroupMemoryLimitInBytes > 1000000*BytesInMebibyte {
+			return filtered, errors.New("Memory limit is unusually high. Not setting heap size")
+		}
 		jvmHeapSizeInBytes := ComputeJVMHeapSizeInBytes(runtime.NumCPU(), cgroupMemoryLimitInBytes)
 		filtered = append(filtered, fmt.Sprintf("-Xms%d", jvmHeapSizeInBytes))
 		filtered = append(filtered, fmt.Sprintf("-Xmx%d", jvmHeapSizeInBytes))

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -287,7 +287,7 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 				// When we fail to get the memory limit from the cgroups files, fallback to using percentage-based heap
 				// sizing. While this method doesn't take into account the per-processor memory offset, it is supported
 				// by all platforms using Java.
-				// Also, when the memory limit is unusually high (defined to be over 1TB), we also revert to the
+				// Also, when the memory limit is unusually high (defined to be over 1TB), we revert to the
 				// percentage-based heap sizing. This is to handle the edge case where the cgroups memory limit is set
 				// to be an arbitrary large value.
 				combinedJvmOpts = filterHeapSizeArgs(combinedJvmOpts)

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -355,7 +355,7 @@ func filterHeapSizeArgsV2(args []string) ([]string, error) {
 		if err != nil {
 			return filtered, errors.Wrap(err, "failed to get cgroup memory limit")
 		}
-		if cgroupMemoryLimitInBytes > 1000000*BytesInMebibyte {
+		if cgroupMemoryLimitInBytes > 1_000_000*BytesInMebibyte {
 			return filtered, errors.New("cgroups memory limit is unusually high. Not setting JVM heap size options")
 		}
 		jvmHeapSizeInBytes := ComputeJVMHeapSizeInBytes(runtime.NumCPU(), cgroupMemoryLimitInBytes)


### PR DESCRIPTION
## Before this PR
In some instances, the memory.limit_in_bytes value is set to an unreasonably large number (like intmax) which is not representative of the true memory limit. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
When the `memory.limit_in_bytes` value is > 1TB, fallback to using 75% {`Initial`/`Max`}`RAMPercentage` values
==COMMIT_MSG==

## Possible downsides?
The memory.limit_in_bytes may legitimately be over 1TB in some instances. I am opting to be conservative for the initial rollout.
