### PR TITLE
Add test to check that heap size is not computed when cgroups memory limits are over 1TB

### DIFF
--- a/changelog/@unreleased/pr-363.v2.yml
+++ b/changelog/@unreleased/pr-363.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add test to check that heap size is not computed when cgroups memory
+    limits are over 1TB
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/363

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -236,7 +236,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			expectError:         false,
 		},
 		{
-			name:                "memory limit too_large",
+			name:                "memory limit too large",
 			numHostProcessors:   1,
 			memoryLimit:         1_000_001 * launchlib.BytesInMebibyte,
 			expectedMaxHeapSize: 0,

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -209,6 +209,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 		numHostProcessors   int
 		memoryLimit         uint64
 		expectedMaxHeapSize uint64
+		expectError         bool
 	}{
 		{
 			name:              "at least 50% of heap",
@@ -216,6 +217,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			memoryLimit:       10 * launchlib.BytesInMebibyte,
 			// 75% of heap - 3mb*processors = 4.5mb
 			expectedMaxHeapSize: 5 * launchlib.BytesInMebibyte,
+			expectError:         false,
 		},
 		{
 			name:              "computes 75% of heap minus 3mb per processor",
@@ -223,6 +225,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			memoryLimit:       16 * launchlib.BytesInMebibyte,
 			// 75% of heap - 3mb*processors = 9mb
 			expectedMaxHeapSize: 9 * launchlib.BytesInMebibyte,
+			expectError:         false,
 		},
 		{
 			name:              "multiple processors",
@@ -230,11 +233,24 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			memoryLimit:       120 * launchlib.BytesInMebibyte,
 			// 75% of heap - 3mb*processors = 81mb
 			expectedMaxHeapSize: 81 * launchlib.BytesInMebibyte,
+			expectError:         false,
+		},
+		{
+			name:                "memory limit too_large",
+			numHostProcessors:   1,
+			memoryLimit:         1_000_001 * launchlib.BytesInMebibyte,
+			expectedMaxHeapSize: 0,
+			expectError:         true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			heapSizeInBytes := launchlib.ComputeJVMHeapSizeInBytes(tc.numHostProcessors, tc.memoryLimit)
-			assert.Equal(t, heapSizeInBytes, tc.expectedMaxHeapSize)
+			heapSizeInBytes, err := launchlib.ComputeJVMHeapSizeInBytes(tc.numHostProcessors, tc.memoryLimit)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, heapSizeInBytes, tc.expectedMaxHeapSize)
+			}
 		})
 	}
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -429,7 +429,7 @@ func isInitialRAMPercentage(arg string) bool {
 // the heap minus 3mb per processor, with a minimum value of 50% of the heap.
 func ComputeJVMHeapSizeInBytes(hostProcessorCount int, cgroupMemoryLimitInBytes uint64) (uint64, error) {
 	if cgroupMemoryLimitInBytes > 1_000_000*BytesInMebibyte {
-		return 0, errors.New("cgroups memory limit is unusually high. Not setting JVM heap size options")
+		return 0, errors.New("cgroups memory limit is unusually high. Not computing JVM heap size")
 	}
 	var memoryLimit = float64(cgroupMemoryLimitInBytes)
 	var processorAdjustment = 3 * BytesInMebibyte * float64(hostProcessorCount)


### PR DESCRIPTION
## After this PR
This PR adds tests for #362. 
==COMMIT_MSG==
Add test to check that heap size is not computed when cgroups memory limits are over 1TB
==COMMIT_MSG==

## Possible downsides?
N/A.

