### PR TITLE
Clarify behavior of custom launcher JVM opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ configVersion: 1
 env:
   CUSTOM_VAR: CUSTOM_VALUE
   CUSTOM_PATH: '{{CWD}}/some/path'
-# Additional JVM options to be passed to the java command, will override defaults in static config. Ignored if configType is "executable"
+# Additional JVM options to be passed to the java command. Ignored if configType is "executable"
 jvmOpts:
   - '-Xmx2g'
 # OPTIONAL - A map of configurations of secondary processes to launch


### PR DESCRIPTION
The README suggests that JVM opts from `launcher-custom.yml` "override" JVM options from `launcher-static.yml`, but this is not the case. The JVM options are concatenated.

The only other modifications we make to the JVM options are for container support.

https://github.com/palantir/go-java-launcher/blob/02b02dadc2ea0f4361dfea0701bebae0b885892d/launchlib/launcher.go#L100-L104

https://github.com/palantir/go-java-launcher/blob/02b02dadc2ea0f4361dfea0701bebae0b885892d/launchlib/launcher.go#L281-L308