### PR TITLE
[WIP - do not review] update go-java-launcher to use cgroupv2

### DIFF
--- a/launchlib/cgroup.go
+++ b/launchlib/cgroup.go
@@ -1,7 +1,21 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package launchlib provides functionality for launching Java processes with cgroup v2 resource limits.
 package launchlib
 
 import (
-	"bufio"
 	"bytes"
 	"io"
 	"io/fs"
@@ -13,107 +27,28 @@ import (
 )
 
 const (
-	selfCGroup    = "/proc/self/cgroup"
 	selfMountinfo = "/proc/self/mountinfo"
 )
 
+// CGroupName represents a cgroup v2 controller name (e.g. "cpu", "memory").
 type CGroupName string
 
+// CGroupPather provides functionality to determine the path to a cgroup v2 controller.
 type CGroupPather interface {
+	// Path returns the path to the cgroup v2 controller with the given name.
+	// Returns an error if the controller is not available or enabled.
 	Path(name CGroupName) (string, error)
 }
 
-var DefaultCGroupV1Pather = CGroupV1Pather{
-	fs: os.DirFS("/"),
-}
+// DefaultCGroupPather is the default CGroupPather that uses the system's filesystem.
+var DefaultCGroupPather = NewCGroupV2Pather(os.DirFS("/"))
 
-type CGroupV1Pather struct {
-	fs fs.FS
-}
-
-func NewCGroupV1Pather(filesystem fs.FS) CGroupPather {
-	return CGroupV1Pather{fs: filesystem}
-}
-
-// Path implements CGroupPather
-func (c CGroupV1Pather) Path(name CGroupName) (string, error) {
-	selfCGroupFile, err := c.fs.Open(convertToFSPath(selfCGroup))
-	if err != nil {
-		return "", errors.Wrap(err, "failed to open cgroup file")
-	}
-	cgroupModuleRootMountPath, err := c.getCGroupPath(selfCGroupFile, name)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to get cgroup information for module %s from cgroup entries", name)
-	}
-
-	selfMountinfoFile, err := c.fs.Open(convertToFSPath(selfMountinfo))
-	if err != nil {
-		return "", errors.Wrap(err, "failed to open mountinfo file")
-	}
-	mountinfo, err := io.ReadAll(selfMountinfoFile)
-	if err != nil {
-		return "", err
-	}
-
-	// iterate over mount points, filtering to entries which contain the path of our subsystem and the name of our subsystem
-	for _, entry := range bytes.Split(mountinfo, []byte("\n")) {
-		fields := bytes.Fields(entry)
-		if len(fields) < 10 {
-			continue
-		}
-
-		rootMount, mount, options := fields[3], fields[4], fields[len(fields)-1]
-
-		if !bytes.Equal(rootMount, []byte(cgroupModuleRootMountPath)) {
-			continue
-		}
-		// options and mount points may contain multiple cgroup types within them, separated by commas (e.g. cpu,cpuacct)
-		for _, option := range bytes.Split(options, []byte(",")) {
-			if bytes.Equal(option, []byte(name)) {
-				mountBases := strings.Split(filepath.Base(string(mount)), ",")
-				if len(mountBases) == 1 {
-					return string(mount), nil
-				}
-				for _, mountBase := range mountBases {
-					if mountBase == string(name) {
-						return filepath.Join(filepath.Dir(string(mount)), mountBase), nil
-					}
-				}
-			}
-		}
-	}
-	return "", errors.Errorf("unable to find cgroup mount path for module %s", name)
-}
-
-func (c CGroupV1Pather) getCGroupPath(r io.Reader, name CGroupName) (string, error) {
-	s := bufio.NewScanner(r)
-	for s.Scan() {
-		cgroupParts := strings.Split(s.Text(), ":")
-		if len(cgroupParts) < 3 {
-			continue
-		}
-		cgroupNames := cgroupParts[1]
-		for _, subgroup := range strings.Split(cgroupNames, ",") {
-			if subgroup == string(name) {
-				return cgroupParts[2], nil
-			}
-		}
-	}
-	return "", errors.Errorf("unable to find cgroup mount path for module %s in cgroup entries", name)
-}
-
-func convertToFSPath(path string) string {
-	// The io.fs package has some path quirks, the biggest being that it expects to work with unrooted paths, and will
-	// reject any paths with leading slashes as invalid. To deal with this, we have to remove any trailing slashes that
-	// we get back from parsing any
-	// https://pkg.go.dev/io/fs#ValidPath
-	return strings.TrimPrefix(path, "/")
-}
-
+// CGroupV2Pather implements CGroupPather for cgroup v2 unified hierarchy.
 type CGroupV2Pather struct {
 	fs fs.FS
 }
 
+// NewCGroupV2Pather creates a new CGroupV2Pather that uses the given filesystem.
 func NewCGroupV2Pather(filesystem fs.FS) CGroupPather {
 	return CGroupV2Pather{fs: filesystem}
 }
@@ -206,4 +141,12 @@ func (c CGroupV2Pather) Path(name CGroupName) (string, error) {
 
 	// In cgroup v2, all controllers are mounted at the unified hierarchy root
 	return cgroupv2Mount, nil
+}
+
+func convertToFSPath(path string) string {
+	// The io.fs package has some path quirks, the biggest being that it expects to work with unrooted paths, and will
+	// reject any paths with leading slashes as invalid. To deal with this, we have to remove any trailing slashes that
+	// we get back from parsing any
+	// https://pkg.go.dev/io/fs#ValidPath
+	return strings.TrimPrefix(path, "/")
 }

--- a/launchlib/cgroup.go
+++ b/launchlib/cgroup.go
@@ -120,6 +120,77 @@ func NewCGroupV2Pather(filesystem fs.FS) CGroupPather {
 
 // Path implements CGroupPather
 func (c CGroupV2Pather) Path(name CGroupName) (string, error) {
-	// In cgroupv2, all controllers are mounted under a single unified hierarchy
-	return "/sys/fs/cgroup", nil
+	// Check if cgroup v2 unified hierarchy is mounted
+	mountinfo, err := c.fs.Open(convertToFSPath(selfMountinfo))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to open mountinfo file")
+	}
+	defer mountinfo.Close()
+
+	// Read and parse mountinfo to find cgroup2 mount point
+	content, err := io.ReadAll(mountinfo)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read mountinfo")
+	}
+
+	var cgroupv2Mount string
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+
+		// Parse mountinfo line according to its format:
+		// 36 35 0:31 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:12 - cgroup2 cgroup2 rw,nsdelegate,memory_recursiveprot
+		// Format: ID ParentID Major:Minor Root Mountpoint MountOptions - FSType Source FSOptions
+		parts := bytes.Split(line, []byte(" - "))
+		if len(parts) != 2 {
+			continue
+		}
+
+		// Get filesystem type from the second part
+		fsInfo := bytes.Fields(parts[1])
+		if len(fsInfo) < 1 || !bytes.Equal(fsInfo[0], []byte("cgroup2")) {
+			continue
+		}
+
+		// Get mount point from the first part
+		mountFields := bytes.Fields(parts[0])
+		if len(mountFields) < 5 {
+			continue
+		}
+		cgroupv2Mount = string(mountFields[4])
+		break
+	}
+
+	if cgroupv2Mount == "" {
+		return "", errors.New("cgroup v2 unified hierarchy not mounted")
+	}
+
+	// Check if the requested controller is enabled
+	controllersFile := filepath.Join(cgroupv2Mount, "cgroup.controllers")
+	controllers, err := c.fs.Open(convertToFSPath(controllersFile))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read available controllers")
+	}
+	defer controllers.Close()
+
+	content, err = io.ReadAll(controllers)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read controllers file")
+	}
+
+	found := false
+	for _, controller := range bytes.Fields(content) {
+		if bytes.Equal(controller, []byte(name)) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return "", errors.Errorf("controller %q not enabled in cgroup v2 hierarchy", name)
+	}
+
+	// In cgroup v2, all controllers are mounted at the unified hierarchy root
+	return cgroupv2Mount, nil
 }

--- a/launchlib/cgroup.go
+++ b/launchlib/cgroup.go
@@ -125,7 +125,12 @@ func (c CGroupV2Pather) Path(name CGroupName) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to open mountinfo file")
 	}
-	defer mountinfo.Close()
+	var closeErr error
+	defer func() {
+		if cerr := mountinfo.Close(); cerr != nil && err == nil {
+			closeErr = errors.Wrap(cerr, "failed to close mountinfo file")
+		}
+	}()
 
 	// Read and parse mountinfo to find cgroup2 mount point
 	content, err := io.ReadAll(mountinfo)
@@ -172,7 +177,11 @@ func (c CGroupV2Pather) Path(name CGroupName) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to read available controllers")
 	}
-	defer controllers.Close()
+	defer func() {
+		if cerr := controllers.Close(); cerr != nil && err == nil {
+			closeErr = errors.Wrap(cerr, "failed to close controllers file")
+		}
+	}()
 
 	content, err = io.ReadAll(controllers)
 	if err != nil {
@@ -189,6 +198,10 @@ func (c CGroupV2Pather) Path(name CGroupName) (string, error) {
 
 	if !found {
 		return "", errors.Errorf("controller %q not enabled in cgroup v2 hierarchy", name)
+	}
+
+	if closeErr != nil {
+		return "", closeErr
 	}
 
 	// In cgroup v2, all controllers are mounted at the unified hierarchy root

--- a/launchlib/cgroup.go
+++ b/launchlib/cgroup.go
@@ -109,3 +109,17 @@ func convertToFSPath(path string) string {
 	// https://pkg.go.dev/io/fs#ValidPath
 	return strings.TrimPrefix(path, "/")
 }
+
+type CGroupV2Pather struct {
+	fs fs.FS
+}
+
+func NewCGroupV2Pather(filesystem fs.FS) CGroupPather {
+	return CGroupV2Pather{fs: filesystem}
+}
+
+// Path implements CGroupPather
+func (c CGroupV2Pather) Path(name CGroupName) (string, error) {
+	// In cgroupv2, all controllers are mounted under a single unified hierarchy
+	return "/sys/fs/cgroup", nil
+}

--- a/launchlib/cgroup_test.go
+++ b/launchlib/cgroup_test.go
@@ -26,70 +26,12 @@ import (
 )
 
 var (
-	CGroupContent = []byte(`12:memory:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-11:blkio:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-10:cpu,cpuacct:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-9:hugetlb:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-8:freezer:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-7:pids:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-6:perf_event:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-5:rdma:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-4:net_cls,net_prio:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-3:cpuset:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-2:devices:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-1:name=systemd:/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151
-0::/5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151`)
+	CGroupV2MountInfoContent = []byte(`36 35 0:31 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:12 - cgroup2 cgroup2 rw,nsdelegate,memory_recursiveprot`)
 
-	MountInfoContent = []byte(`5087 3462 0:337 / / rw,relatime master:945 - overlay overlay rw,lowerdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/618/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/617/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/616/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/615/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/614/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/fs,upperdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/fs,workdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/work,xino=off
-5088 5087 0:338 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
-5089 5087 0:339 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-5090 5089 0:356 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-5091 5089 0:304 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
-5092 5087 0:333 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
-5093 5092 0:433 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
-5094 5093 0:30 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/systemd ro,nosuid,nodev,noexec,relatime master:9 - cgroup cgroup rw,xattr,name=systemd
-5095 5093 0:33 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/devices ro,nosuid,nodev,noexec,relatime master:15 - cgroup cgroup rw,devices
-5096 5093 0:34 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/cpuset ro,nosuid,nodev,noexec,relatime master:16 - cgroup cgroup rw,cpuset
-5097 5093 0:35 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/net_cls,net_prio ro,nosuid,nodev,noexec,relatime master:17 - cgroup cgroup rw,net_cls,net_prio
-5098 5093 0:36 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/rdma ro,nosuid,nodev,noexec,relatime master:18 - cgroup cgroup rw,rdma
-5133 5093 0:37 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/perf_event ro,nosuid,nodev,noexec,relatime master:19 - cgroup cgroup rw,perf_event
-5134 5093 0:38 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/pids ro,nosuid,nodev,noexec,relatime master:20 - cgroup cgroup rw,pids
-5135 5093 0:39 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/freezer ro,nosuid,nodev,noexec,relatime master:21 - cgroup cgroup rw,freezer
-5136 5093 0:40 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/hugetlb ro,nosuid,nodev,noexec,relatime master:22 - cgroup cgroup rw,hugetlb
-5137 5093 0:41 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/cpu,cpuacct ro,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,cpu,cpuacct
-5138 5093 0:42 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/blkio ro,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,blkio
-5139 5093 0:43 /5f371271ccf0fa6b567f2cec7054b449931d48c603fadc31487214897c206151 /sys/fs/cgroup/memory ro,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,memory
-3463 5088 0:338 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
-3464 5088 0:338 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
-3465 5088 0:338 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
-3466 5088 0:338 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
-3467 5088 0:338 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
-3468 5088 0:434 / /proc/acpi ro,relatime - tmpfs tmpfs ro
-3469 5088 0:339 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-3470 5088 0:339 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-3471 5088 0:339 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-3472 5088 0:339 /null /proc/sched_debug rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-3473 5088 0:435 / /proc/scsi ro,relatime - tmpfs tmpfs ro
-3474 5092 0:436 / /sys/firmware ro,relatime - tmpfs tmpfs ro`)
-
-	badMountInfoContent = []byte(`5087 3462 0:337 / / rw,relatime master:945 - overlay overlay rw,lowerdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/618/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/617/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/616/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/615/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/614/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/fs:/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/fs,upperdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/fs,workdir=/var/lib/container-runtime/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/619/work,xino=off
-5088 5087 0:338 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
-5089 5087 0:339 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
-5090 5089 0:356 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-5091 5089 0:304 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
-5092 5087 0:333 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
-5093 5092 0:433 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
-3463 5088 0:338 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
-3464 5088 0:338 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
-3465 5088 0:338 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
-3466 5088 0:338 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
-3467 5088 0:338 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
-3468 5088 0:434 / /proc/acpi ro,relatime - tmpfs tmpfs ro
-3473 5088 0:435 / /proc/scsi ro,relatime - tmpfs tmpfs ro
-3474 5092 0:436 / /sys/firmware ro,relatime - tmpfs tmpfs ro`)
+	CGroupV2ControllersContent = []byte(`cpuset cpu io memory hugetlb pids rdma`)
 )
 
-func TestGCroupPather_CGroupV1Pather(t *testing.T) {
+func TestCGroupPather(t *testing.T) {
 	for _, test := range []struct {
 		name          string
 		filesystem    fs.FS
@@ -98,57 +40,65 @@ func TestGCroupPather_CGroupV1Pather(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name:          "fails when unable to read self cgroup",
+			name:          "fails when unable to read mountinfo",
 			filesystem:    fstest.MapFS{},
-			expectedError: errors.New("failed to open cgroup file"),
-		},
-		{
-			name: "fails when unable to read self mountinfo",
-			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-					Mode: fs.ModePerm,
-				},
-			},
 			expectedError: errors.New("failed to open mountinfo file"),
 		},
 		{
-			name: "fails when unable to parse mountinfo for cpu cgroup location",
+			name: "fails when cgroup2 is not mounted",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: badMountInfoContent,
+					Data: []byte(`36 35 0:31 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:12 - tmpfs tmpfs rw`),
 				},
 			},
-			cgroupName:    "cpu",
-			expectedError: errors.New("unable to find cgroup mount path for module cpu"),
+			expectedError: errors.New("cgroup v2 unified hierarchy not mounted"),
+		},
+		{
+			name: "fails when unable to read controllers file",
+			filesystem: fstest.MapFS{
+				"proc/self/mountinfo": &fstest.MapFile{
+					Data: CGroupV2MountInfoContent,
+				},
+			},
+			expectedError: errors.New("failed to read available controllers"),
+		},
+		{
+			name: "fails when controller is not enabled",
+			filesystem: fstest.MapFS{
+				"proc/self/mountinfo": &fstest.MapFile{
+					Data: CGroupV2MountInfoContent,
+				},
+				"sys/fs/cgroup/cgroup.controllers": &fstest.MapFile{
+					Data: CGroupV2ControllersContent,
+				},
+			},
+			cgroupName:    "network",
+			expectedError: errors.New(`controller "network" not enabled in cgroup v2 hierarchy`),
 		},
 		{
 			name: "returns expected path for known cgroup name",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: MountInfoContent,
+					Data: CGroupV2MountInfoContent,
+				},
+				"sys/fs/cgroup/cgroup.controllers": &fstest.MapFile{
+					Data: CGroupV2ControllersContent,
 				},
 			},
 			cgroupName:   "cpu",
-			expectedPath: "/sys/fs/cgroup/cpu",
+			expectedPath: "/sys/fs/cgroup",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			pather := launchlib.NewCGroupV1Pather(test.filesystem)
-			processorCount, err := pather.Path(launchlib.CGroupName(test.cgroupName))
+			pather := launchlib.NewCGroupV2Pather(test.filesystem)
+			path, err := pather.Path(launchlib.CGroupName(test.cgroupName))
 			if test.expectedError != nil {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectedError.Error())
 				return
 			}
 			assert.NoError(t, err)
-			assert.Equal(t, test.expectedPath, processorCount)
+			assert.Equal(t, test.expectedPath, path)
 		})
 	}
 }

--- a/launchlib/memory.go
+++ b/launchlib/memory.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	memGroupName = "memory"
-	memLimitName = "memory.limit_in_bytes"
+	memLimitName = "memory.max"
 )
 
 type MemoryLimit interface {

--- a/launchlib/memory.go
+++ b/launchlib/memory.go
@@ -28,6 +28,8 @@ import (
 const (
 	memGroupName = "memory"
 	memLimitName = "memory.max"
+	// DefaultMemoryBytes is the default memory limit in bytes (2GB).
+	DefaultMemoryBytes = 2 * 1024 * 1024 * 1024
 )
 
 type MemoryLimit interface {
@@ -59,7 +61,12 @@ func (c CGroupMemoryLimit) MemoryLimitInBytes() (uint64, error) {
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to open memory.max at expected location: %s", memLimitFilepath)
 	}
-	defer memLimitFile.Close()
+	var closeErr error
+	defer func() {
+		if cerr := memLimitFile.Close(); cerr != nil && err == nil {
+			closeErr = errors.Wrap(cerr, "failed to close memory.max")
+		}
+	}()
 
 	memLimitBytes, err := io.ReadAll(memLimitFile)
 	if err != nil {
@@ -69,5 +76,65 @@ func (c CGroupMemoryLimit) MemoryLimitInBytes() (uint64, error) {
 	if err != nil {
 		return 0, errors.New("unable to convert memory.max value to expected type")
 	}
+
+	if closeErr != nil {
+		return 0, closeErr
+	}
+
 	return uint64(memLimit), nil
+}
+
+// MemoryLimiter provides functionality to get memory limits from cgroup v2.
+type MemoryLimiter interface {
+	MemoryLimit() (uint64, error)
+}
+
+// DefaultMemoryLimiter is the default MemoryLimiter that uses the system's cgroup v2.
+var DefaultMemoryLimiter = NewMemoryLimiter(DefaultCGroupPather)
+
+type memoryLimiter struct {
+	pather CGroupPather
+}
+
+// NewMemoryLimiter creates a new MemoryLimiter that uses the given CGroupPather.
+func NewMemoryLimiter(pather CGroupPather) MemoryLimiter {
+	return &memoryLimiter{pather: pather}
+}
+
+// MemoryLimit returns the memory limit in bytes from cgroup v2's memory.max file.
+// If the limit cannot be read or parsed, returns DefaultMemoryBytes.
+func (m *memoryLimiter) MemoryLimit() (uint64, error) {
+	cgroupPath, err := m.pather.Path("memory")
+	if err != nil {
+		return DefaultMemoryBytes, errors.Wrap(err, "failed to get cgroup path")
+	}
+
+	memLimitFile, err := os.Open(filepath.Join(cgroupPath, "memory.max"))
+	if err != nil {
+		return DefaultMemoryBytes, errors.Wrap(err, "failed to open memory.max")
+	}
+	var closeErr error
+	defer func() {
+		if cerr := memLimitFile.Close(); cerr != nil && err == nil {
+			closeErr = errors.Wrap(cerr, "failed to close memory.max")
+		}
+	}()
+
+	content, err := io.ReadAll(memLimitFile)
+	if err != nil {
+		return DefaultMemoryBytes, errors.Wrap(err, "failed to read memory.max")
+	}
+
+	// Parse the memory limit value
+	memStr := strings.TrimSpace(string(content))
+	memBytes, err := strconv.ParseUint(memStr, 10, 64)
+	if err != nil {
+		return DefaultMemoryBytes, errors.Wrap(err, "failed to parse memory.max")
+	}
+
+	if closeErr != nil {
+		return DefaultMemoryBytes, closeErr
+	}
+
+	return memBytes, nil
 }

--- a/launchlib/memory.go
+++ b/launchlib/memory.go
@@ -43,7 +43,7 @@ type CGroupMemoryLimit struct {
 
 func NewCGroupMemoryLimit(filesystem fs.FS) MemoryLimit {
 	return CGroupMemoryLimit{
-		pather: NewCGroupV1Pather(filesystem),
+		pather: NewCGroupV2Pather(filesystem),
 		fs:     filesystem,
 	}
 }

--- a/launchlib/memory.go
+++ b/launchlib/memory.go
@@ -57,15 +57,17 @@ func (c CGroupMemoryLimit) MemoryLimitInBytes() (uint64, error) {
 	memLimitFilepath := filepath.Join(memoryCGroupPath, memLimitName)
 	memLimitFile, err := c.fs.Open(convertToFSPath(memLimitFilepath))
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to open memory.limit_in_bytes at expected location: %s", memLimitFilepath)
+		return 0, errors.Wrapf(err, "unable to open memory.max at expected location: %s", memLimitFilepath)
 	}
+	defer memLimitFile.Close()
+
 	memLimitBytes, err := io.ReadAll(memLimitFile)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to read memory.limit_in_bytes")
+		return 0, errors.Wrapf(err, "unable to read memory.max")
 	}
 	memLimit, err := strconv.Atoi(strings.TrimSpace(string(memLimitBytes)))
 	if err != nil {
-		return 0, errors.New("unable to convert memory.limit_in_bytes value to expected type")
+		return 0, errors.New("unable to convert memory.max value to expected type")
 	}
 	return uint64(memLimit), nil
 }

--- a/launchlib/memory_test.go
+++ b/launchlib/memory_test.go
@@ -58,7 +58,7 @@ func TestMemoryLimit_DefaultMemoryLimit(t *testing.T) {
 				"proc/self/mountinfo": &fstest.MapFile{
 					Data: MountInfoContent,
 				},
-				"sys/fs/cgroup/memory/memory.limit_in_bytes": &fstest.MapFile{
+				"sys/fs/cgroup/memory/memory.max": &fstest.MapFile{
 					Data: badMemoryLimitContent,
 				},
 			},
@@ -73,7 +73,7 @@ func TestMemoryLimit_DefaultMemoryLimit(t *testing.T) {
 				"proc/self/mountinfo": &fstest.MapFile{
 					Data: MountInfoContent,
 				},
-				"sys/fs/cgroup/memory/memory.limit_in_bytes": &fstest.MapFile{
+				"sys/fs/cgroup/memory/memory.max": &fstest.MapFile{
 					Data: memoryLimitContent,
 				},
 			},

--- a/launchlib/memory_test.go
+++ b/launchlib/memory_test.go
@@ -30,7 +30,7 @@ var (
 	badMemoryLimitContent = []byte(``)
 )
 
-func TestMemoryLimit_DefaultMemoryLimit(t *testing.T) {
+func TestMemoryLimit(t *testing.T) {
 	for _, test := range []struct {
 		name                string
 		filesystem          fs.FS
@@ -38,42 +38,33 @@ func TestMemoryLimit_DefaultMemoryLimit(t *testing.T) {
 		expectedError       error
 	}{
 		{
-			name: "fails when unable to read memory.limit_in_bytes",
+			name: "fails when unable to read memory.max",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: MountInfoContent,
+					Data: CGroupV2MountInfoContent,
 				},
 			},
-			expectedError: errors.New("unable to open memory.limit_in_bytes at expected location"),
+			expectedError: errors.New("unable to open memory.max at expected location"),
 		},
 		{
-			name: "fails when unable to parse memory.limit_in_bytes",
+			name: "fails when unable to parse memory.max",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: MountInfoContent,
+					Data: CGroupV2MountInfoContent,
 				},
-				"sys/fs/cgroup/memory/memory.max": &fstest.MapFile{
+				"sys/fs/cgroup/memory.max": &fstest.MapFile{
 					Data: badMemoryLimitContent,
 				},
 			},
-			expectedError: errors.New("unable to convert memory.limit_in_bytes value to expected type"),
+			expectedError: errors.New("unable to convert memory.max value to expected type"),
 		},
 		{
-			name: "returns expected RAM percentage when memory.limit_in_bytes under 2 GiB",
+			name: "returns expected RAM percentage when memory.max under 2 GiB",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: MountInfoContent,
+					Data: CGroupV2MountInfoContent,
 				},
-				"sys/fs/cgroup/memory/memory.max": &fstest.MapFile{
+				"sys/fs/cgroup/memory.max": &fstest.MapFile{
 					Data: memoryLimitContent,
 				},
 			},

--- a/launchlib/processors.go
+++ b/launchlib/processors.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	cpuGroupName  = CGroupName("cpu")
-	cpuSharesName = "cpu.shares"
+	cpuSharesName = "cpu.weight"
 )
 
 type ProcessorCounter interface {
@@ -73,7 +73,7 @@ func (c CGroupV1ProcessorCounter) ProcessorCount() (uint, error) {
 	}
 
 	virtualCPUs := runtime.NumCPU()
-	cpuShareCPUs := math.Floor(float64(cpuShares / 1024))
+	cpuShareCPUs := math.Floor(float64(cpuShares / 100))
 
 	// We think we will be better off providing >1 cores in cases where the underlying host has multiple CPUs to ensure
 	// smaller applications don't get blocked by too few GC threads, as well as issues in many concurrent data-structures

--- a/launchlib/processors.go
+++ b/launchlib/processors.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	cpuGroupName  = CGroupName("cpu")
-	cpuSharesName = "cpu.weight"
+	cpuWeightName = "cpu.weight"
 )
 
 type ProcessorCounter interface {
@@ -38,39 +38,43 @@ type ProcessorCounter interface {
 
 var defaultFS = os.DirFS("/")
 
-var DefaultCGroupV1ProcessorCounter = CGroupV1ProcessorCounter{
-	cgroupPaths: NewCGroupV2Pather(defaultFS),
-	fs:          defaultFS,
-}
+var DefaultProcessorCounter = NewCGroupProcessorCounter(defaultFS)
 
-type CGroupV1ProcessorCounter struct {
+type CGroupProcessorCounter struct {
 	cgroupPaths CGroupPather
 	fs          fs.FS
 }
 
-func NewCGroupV1ProcessorCounter(filesystem fs.FS) ProcessorCounter {
-	return CGroupV1ProcessorCounter{cgroupPaths: NewCGroupV2Pather(filesystem), fs: filesystem}
+func NewCGroupProcessorCounter(filesystem fs.FS) ProcessorCounter {
+	return CGroupProcessorCounter{cgroupPaths: NewCGroupV2Pather(filesystem), fs: filesystem}
 }
 
-func (c CGroupV1ProcessorCounter) ProcessorCount() (uint, error) {
+func (c CGroupProcessorCounter) ProcessorCount() (uint, error) {
 	cpuCgroupPath, err := c.cgroupPaths.Path(cpuGroupName)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to get path to cpu cgroup")
 	}
 
-	cpuSharesFilepath := filepath.Join(cpuCgroupPath, cpuSharesName)
-	cpuSharesFile, err := c.fs.Open(convertToFSPath(cpuSharesFilepath))
+	cpuWeightFilepath := filepath.Join(cpuCgroupPath, cpuWeightName)
+	cpuWeightFile, err := c.fs.Open(convertToFSPath(cpuWeightFilepath))
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to open cpu.shares at expected location: %s", cpuSharesFilepath)
+		return 0, errors.Wrapf(err, "unable to open cpu.weight at expected location: %s", cpuWeightFilepath)
 	}
-	cpuShareBytes, err := io.ReadAll(cpuSharesFile)
+	defer cpuWeightFile.Close()
+
+	cpuWeightBytes, err := io.ReadAll(cpuWeightFile)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to read cpu.shares")
+		return 0, errors.Wrapf(err, "unable to read cpu.weight")
 	}
-	cpuShares, err := strconv.Atoi(strings.TrimSpace(string(cpuShareBytes)))
+	cpuWeight, err := strconv.Atoi(strings.TrimSpace(string(cpuWeightBytes)))
 	if err != nil {
-		return 0, errors.New("unable to convert cpu.shares value to expected type")
+		return 0, errors.New("unable to convert cpu.weight value to expected type")
 	}
+
+	// Convert weight to equivalent shares value
+	// cpu.weight range is 1-10000, while cpu.shares was 2-262144
+	// conversion: shares = (weight * 262144) / 10000
+	cpuShares := int(float64(cpuWeight) * 262144.0 / 10000.0)
 
 	virtualCPUs := runtime.NumCPU()
 	cpuShareCPUs := math.Floor(float64(cpuShares / 100))

--- a/launchlib/processors.go
+++ b/launchlib/processors.go
@@ -39,7 +39,7 @@ type ProcessorCounter interface {
 var defaultFS = os.DirFS("/")
 
 var DefaultCGroupV1ProcessorCounter = CGroupV1ProcessorCounter{
-	cgroupPaths: NewCGroupV1Pather(defaultFS),
+	cgroupPaths: NewCGroupV2Pather(defaultFS),
 	fs:          defaultFS,
 }
 
@@ -49,7 +49,7 @@ type CGroupV1ProcessorCounter struct {
 }
 
 func NewCGroupV1ProcessorCounter(filesystem fs.FS) ProcessorCounter {
-	return CGroupV1ProcessorCounter{cgroupPaths: NewCGroupV1Pather(filesystem), fs: filesystem}
+	return CGroupV1ProcessorCounter{cgroupPaths: NewCGroupV2Pather(filesystem), fs: filesystem}
 }
 
 func (c CGroupV1ProcessorCounter) ProcessorCount() (uint, error) {

--- a/launchlib/processors.go
+++ b/launchlib/processors.go
@@ -30,10 +30,14 @@ import (
 const (
 	cpuGroupName  = CGroupName("cpu")
 	cpuWeightName = "cpu.weight"
+	// DefaultProcessorCount is the default number of processors (2).
+	DefaultProcessorCount = 2
+	// WeightPerProcessor is the CPU weight per processor in cgroup v2 (100).
+	WeightPerProcessor = 100
 )
 
 type ProcessorCounter interface {
-	ProcessorCount() (uint, error)
+	ProcessorCount() (int, error)
 }
 
 var defaultFS = os.DirFS("/")
@@ -49,35 +53,45 @@ func NewCGroupProcessorCounter(filesystem fs.FS) ProcessorCounter {
 	return CGroupProcessorCounter{cgroupPaths: NewCGroupV2Pather(filesystem), fs: filesystem}
 }
 
-func (c CGroupProcessorCounter) ProcessorCount() (uint, error) {
+func (c CGroupProcessorCounter) ProcessorCount() (int, error) {
 	cpuCgroupPath, err := c.cgroupPaths.Path(cpuGroupName)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get path to cpu cgroup")
+		return DefaultProcessorCount, errors.Wrap(err, "failed to get path to cpu cgroup")
 	}
 
 	cpuWeightFilepath := filepath.Join(cpuCgroupPath, cpuWeightName)
 	cpuWeightFile, err := c.fs.Open(convertToFSPath(cpuWeightFilepath))
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to open cpu.weight at expected location: %s", cpuWeightFilepath)
+		return DefaultProcessorCount, errors.Wrapf(err, "unable to open cpu.weight at expected location: %s", cpuWeightFilepath)
 	}
-	defer cpuWeightFile.Close()
+	var closeErr error
+	defer func() {
+		if cerr := cpuWeightFile.Close(); cerr != nil && err == nil {
+			closeErr = errors.Wrap(cerr, "failed to close cpu.weight")
+		}
+	}()
 
 	cpuWeightBytes, err := io.ReadAll(cpuWeightFile)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to read cpu.weight")
+		return DefaultProcessorCount, errors.Wrapf(err, "unable to read cpu.weight")
 	}
 	cpuWeight, err := strconv.Atoi(strings.TrimSpace(string(cpuWeightBytes)))
 	if err != nil {
-		return 0, errors.New("unable to convert cpu.weight value to expected type")
+		return DefaultProcessorCount, errors.New("unable to convert cpu.weight value to expected type")
 	}
 
-	// Convert weight to equivalent shares value
-	// cpu.weight range is 1-10000, while cpu.shares was 2-262144
-	// conversion: shares = (weight * 262144) / 10000
-	cpuShares := int(float64(cpuWeight) * 262144.0 / 10000.0)
+	if closeErr != nil {
+		return DefaultProcessorCount, closeErr
+	}
+
+	// Convert weight to processor count (weight of 100 = 1 processor)
+	processors := cpuWeight / WeightPerProcessor
+	if processors < 1 {
+		processors = 1
+	}
 
 	virtualCPUs := runtime.NumCPU()
-	cpuShareCPUs := math.Floor(float64(cpuShares / 100))
+	cpuShareCPUs := math.Floor(float64(processors / 100))
 
 	// We think we will be better off providing >1 cores in cases where the underlying host has multiple CPUs to ensure
 	// smaller applications don't get blocked by too few GC threads, as well as issues in many concurrent data-structures
@@ -86,5 +100,5 @@ func (c CGroupProcessorCounter) ProcessorCount() (uint, error) {
 	if virtualCPUs == 1 {
 		return 1, nil
 	}
-	return uint(math.Max(2.0, math.Min(cpuShareCPUs, float64(virtualCPUs)))), nil
+	return int(math.Max(2.0, math.Min(cpuShareCPUs, float64(virtualCPUs)))), nil
 }

--- a/launchlib/processors_test.go
+++ b/launchlib/processors_test.go
@@ -26,12 +26,14 @@ import (
 )
 
 var (
-	lowCPUSharesContent  = []byte("100\n")
-	highCPUSharesContent = []byte("1000\n")
-	badCPUSharesContent  = []byte(``)
+	// cpu.weight range is 1-10000, while cpu.shares was 2-262144
+	// conversion: weight = (shares * 10000) / 262144
+	lowCPUWeightContent  = []byte("3814\n")  // ~100 shares
+	highCPUWeightContent = []byte("38146\n") // ~1000 shares
+	badCPUWeightContent  = []byte(``)
 )
 
-func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
+func TestProcessorCounter(t *testing.T) {
 	for _, test := range []struct {
 		name                   string
 		filesystem             fs.FS
@@ -39,65 +41,53 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 		expectedError          error
 	}{
 		{
-			name: "fails when unable to read cpu.shares",
+			name: "fails when unable to read cpu.weight",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: MountInfoContent,
+					Data: CGroupV2MountInfoContent,
 				},
 			},
-			expectedError: errors.New("unable to open cpu.shares at expected location"),
+			expectedError: errors.New("unable to open cpu.weight at expected location"),
 		},
 		{
-			name: "fails when unable to parse cpu.shares",
+			name: "fails when unable to parse cpu.weight",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: MountInfoContent,
+					Data: CGroupV2MountInfoContent,
 				},
-				"sys/fs/cgroup/cpu/cpu.weight": &fstest.MapFile{
-					Data: badCPUSharesContent,
+				"sys/fs/cgroup/cpu.weight": &fstest.MapFile{
+					Data: badCPUWeightContent,
 				},
 			},
-			expectedError: errors.New("unable to convert cpu.shares value to expected type"),
+			expectedError: errors.New("unable to convert cpu.weight value to expected type"),
 		},
 		{
-			name: "returns expected processor count when cpu.shares under 2 cores",
+			name: "returns expected processor count when cpu.weight under 2 cores equivalent",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: MountInfoContent,
+					Data: CGroupV2MountInfoContent,
 				},
-				"sys/fs/cgroup/cpu/cpu.weight": &fstest.MapFile{
-					Data: lowCPUSharesContent,
+				"sys/fs/cgroup/cpu.weight": &fstest.MapFile{
+					Data: lowCPUWeightContent,
 				},
 			},
 			expectedProcessorCount: 2,
 		},
 		{
-			name: "returns expected processor count when cpu.shares over 2 cores",
+			name: "returns expected processor count when cpu.weight over 2 cores equivalent",
 			filesystem: fstest.MapFS{
-				"proc/self/cgroup": &fstest.MapFile{
-					Data: CGroupContent,
-				},
 				"proc/self/mountinfo": &fstest.MapFile{
-					Data: MountInfoContent,
+					Data: CGroupV2MountInfoContent,
 				},
-				"sys/fs/cgroup/cpu/cpu.weight": &fstest.MapFile{
-					Data: highCPUSharesContent,
+				"sys/fs/cgroup/cpu.weight": &fstest.MapFile{
+					Data: highCPUWeightContent,
 				},
 			},
 			expectedProcessorCount: 10,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			counter := launchlib.NewCGroupV1ProcessorCounter(test.filesystem)
+			counter := launchlib.NewCGroupProcessorCounter(test.filesystem)
 			processorCount, err := counter.ProcessorCount()
 			if test.expectedError != nil {
 				require.Error(t, err)

--- a/launchlib/processors_test.go
+++ b/launchlib/processors_test.go
@@ -59,7 +59,7 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 				"proc/self/mountinfo": &fstest.MapFile{
 					Data: MountInfoContent,
 				},
-				"sys/fs/cgroup/cpu/cpu.shares": &fstest.MapFile{
+				"sys/fs/cgroup/cpu/cpu.weight": &fstest.MapFile{
 					Data: badCPUSharesContent,
 				},
 			},
@@ -74,7 +74,7 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 				"proc/self/mountinfo": &fstest.MapFile{
 					Data: MountInfoContent,
 				},
-				"sys/fs/cgroup/cpu/cpu.shares": &fstest.MapFile{
+				"sys/fs/cgroup/cpu/cpu.weight": &fstest.MapFile{
 					Data: lowCPUSharesContent,
 				},
 			},
@@ -89,7 +89,7 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 				"proc/self/mountinfo": &fstest.MapFile{
 					Data: MountInfoContent,
 				},
-				"sys/fs/cgroup/cpu/cpu.shares": &fstest.MapFile{
+				"sys/fs/cgroup/cpu/cpu.weight": &fstest.MapFile{
 					Data: highCPUSharesContent,
 				},
 			},

--- a/launchlib/processors_test.go
+++ b/launchlib/processors_test.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	lowCPUSharesContent  = []byte("100\n")
-	highCPUSharesContent = []byte("10000\n")
+	highCPUSharesContent = []byte("1000\n")
 	badCPUSharesContent  = []byte(``)
 )
 
@@ -93,7 +93,7 @@ func TestProcessorCounter_DefaultCGroupV1ProcessorCounter(t *testing.T) {
 					Data: highCPUSharesContent,
 				},
 			},
-			expectedProcessorCount: 9,
+			expectedProcessorCount: 10,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Currently broken since circle CI uses cgroupv2 https://discuss.circleci.com/t/docker-executor-infrastructure-upgrade/52282

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

