### PR TITLE
Add heapPercentage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ To override the heap percentage, developers can set `heap-percentage` in ``launc
 
 Alternatively, developers can override the heap percentage in containers by specifying both ``-XX:MaxRAMPercentage=`` and ``-XX:InitialRAMPercentage=`` and we recommend setting both to the same value. Note that setting ``-XX:MaxRAMPercentage=`` and ``-XX:InitialRAMPercentage=`` to the same value does not prevent the heap from shrinking. 
 
+If either ``-XX:MaxRAMPercentage=`` or ``-XX:InitialRAMPercentage=`` are set, `heap-percentage` will be ignored. 
+
 Developers can specify both ``MaxRAMPercentage|InitialRAMPercentage``
 together with ``-Xmx|-Xms`` overrides safely: ``-Xmx/-Xms`` overrides ALWAYS take precedence and will be filtered out
 when running inside a container, as per logic detailed above.

--- a/README.md
+++ b/README.md
@@ -161,11 +161,9 @@ percentage of ``MaxRAM`` value, e.g. ``max-heap-size = MaxRAM * MaxRamPercentage
 
 ### Overriding default values
 
-To override the heap percentage, developers can set `heap-percentage` in ``launcher-custom.yml``. This will use the cgroups memory limit to calculate the ``-Xmx|-Xms`` values, without the per processor adjustment. Setting ``-Xmx`` and ``-Xms`` equal to each other ensures the heap will never shrink. 
+To override the heap percentage, developers can set `heap-percentage` in ``launcher-custom.yml``. This will use the cgroups memory limit to calculate the ``-Xmx|-Xms`` values, without the per processor adjustment. Setting ``-Xmx`` and ``-Xms`` to the same value ensures the heap will never shrink. 
 
-Alternatively, developers can override the heap percentage in containers by specifying both ``-XX:MaxRAMPercentage=``
-and ``-XX:InitialRAMPercentage=`` and we recommend setting both to the same value. Setting ``-XX:MaxRAMPercentage=``
-and ``-XX:InitialRAMPercentage=`` does not guarantee the heap will not shrink. 
+Alternatively, developers can override the heap percentage in containers by specifying both ``-XX:MaxRAMPercentage=`` and ``-XX:InitialRAMPercentage=`` and we recommend setting both to the same value. Note that setting ``-XX:MaxRAMPercentage=`` and ``-XX:InitialRAMPercentage=`` to the same value does not prevent the heap from shrinking. 
 
 Developers can specify both ``MaxRAMPercentage|InitialRAMPercentage``
 together with ``-Xmx|-Xms`` overrides safely: ``-Xmx/-Xms`` overrides ALWAYS take precedence and will be filtered out

--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ percentage of ``MaxRAM`` value, e.g. ``max-heap-size = MaxRAM * MaxRamPercentage
 
 ### Overriding default values
 
-To override the heap percentage, developers can set `heap-percentage` in ``launcher-custom.yml``. This will use the cgroups memory limit to calculate the ``-Xmx|-Xms`` values, without the per processor adjustment. Setting ``-Xmx`` and ``-Xms`` to the same value ensures the heap will never shrink. 
+To override the heap percentage, developers can set `heapPercentage` in ``launcher-custom.yml``. This will use the cgroups memory limit to calculate the ``-Xmx|-Xms`` values, without the per processor adjustment. Setting ``-Xmx`` and ``-Xms`` to the same value ensures the heap will never shrink. 
 
 Alternatively, developers can override the heap percentage in containers by specifying both ``-XX:MaxRAMPercentage=`` and ``-XX:InitialRAMPercentage=`` and we recommend setting both to the same value. Note that setting ``-XX:MaxRAMPercentage=`` and ``-XX:InitialRAMPercentage=`` to the same value does not prevent the heap from shrinking. 
 
-If either ``-XX:MaxRAMPercentage=`` or ``-XX:InitialRAMPercentage=`` are set, `heap-percentage` will be ignored. 
+If either ``-XX:MaxRAMPercentage=`` or ``-XX:InitialRAMPercentage=`` are set, `heapPercentage` will be ignored. 
 
 Developers can specify both ``MaxRAMPercentage|InitialRAMPercentage``
 together with ``-Xmx|-Xms`` overrides safely: ``-Xmx/-Xms`` overrides ALWAYS take precedence and will be filtered out

--- a/README.md
+++ b/README.md
@@ -161,8 +161,11 @@ percentage of ``MaxRAM`` value, e.g. ``max-heap-size = MaxRAM * MaxRamPercentage
 
 ### Overriding default values
 
-Developers can override the heap percentage in containers by specifying both ``-XX:MaxRAMPercentage=``
-and ``-XX:InitialRAMPercentage=`` and we recommend setting both to the same value.
+To override the heap percentage, developers can set `heap-percentage` in ``launcher-custom.yml``. This will use the cgroups memory limit to calculate the ``-Xmx|-Xms`` values, without the per processor adjustment. Setting ``-Xmx`` and ``-Xms`` equal to each other ensures the heap will never shrink. 
+
+Alternatively, developers can override the heap percentage in containers by specifying both ``-XX:MaxRAMPercentage=``
+and ``-XX:InitialRAMPercentage=`` and we recommend setting both to the same value. Setting ``-XX:MaxRAMPercentage=``
+and ``-XX:InitialRAMPercentage=`` does not guarantee the heap will not shrink. 
 
 Developers can specify both ``MaxRAMPercentage|InitialRAMPercentage``
 together with ``-Xmx|-Xms`` overrides safely: ``-Xmx/-Xms`` overrides ALWAYS take precedence and will be filtered out

--- a/changelog/@unreleased/pr-557.v2.yml
+++ b/changelog/@unreleased/pr-557.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add heapPercentage configuration
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/557

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -185,6 +185,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 		name                string
 		numHostProcessors   int
 		memoryLimit         uint64
+		heapPercentage      *float64
 		expectedMaxHeapSize uint64
 		expectError         bool
 	}{
@@ -192,6 +193,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			name:              "at least 50% of heap",
 			numHostProcessors: 1,
 			memoryLimit:       10 * launchlib.BytesInMebibyte,
+			heapPercentage:    nil,
 			// 75% of heap - 3mb*processors = 4.5mb
 			expectedMaxHeapSize: 5 * launchlib.BytesInMebibyte,
 			expectError:         false,
@@ -200,6 +202,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			name:              "computes 75% of heap minus 3mb per processor",
 			numHostProcessors: 1,
 			memoryLimit:       16 * launchlib.BytesInMebibyte,
+			heapPercentage:    nil,
 			// 75% of heap - 3mb*processors = 9mb
 			expectedMaxHeapSize: 9 * launchlib.BytesInMebibyte,
 			expectError:         false,
@@ -208,6 +211,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			name:              "multiple processors",
 			numHostProcessors: 3,
 			memoryLimit:       120 * launchlib.BytesInMebibyte,
+			heapPercentage:    nil,
 			// 75% of heap - 3mb*processors = 81mb
 			expectedMaxHeapSize: 81 * launchlib.BytesInMebibyte,
 			expectError:         false,
@@ -216,12 +220,21 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			name:                "memory limit too large",
 			numHostProcessors:   1,
 			memoryLimit:         1_000_001 * launchlib.BytesInMebibyte,
+			heapPercentage:      nil,
 			expectedMaxHeapSize: 0,
 			expectError:         true,
 		},
+		{
+			name:                "computes heap as 10% of memory limit using heapPercentage",
+			numHostProcessors:   3,
+			memoryLimit:         10 * launchlib.BytesInMebibyte,
+			heapPercentage:      toPointer(10.0),
+			expectedMaxHeapSize: 1 * launchlib.BytesInMebibyte,
+			expectError:         false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			heapSizeInBytes, err := launchlib.ComputeJVMHeapSizeInBytes(tc.numHostProcessors, tc.memoryLimit)
+			heapSizeInBytes, err := launchlib.ComputeJVMHeapSizeInBytes(tc.numHostProcessors, tc.memoryLimit, tc.heapPercentage)
 			if tc.expectError {
 				assert.Error(t, err)
 			} else {
@@ -312,4 +325,8 @@ func TestMain(m *testing.M) {
 		log.Fatalln("Failed to set a mock JAVA_HOME", err)
 	}
 	os.Exit(m.Run())
+}
+
+func toPointer[T any](t T) *T {
+	return &t
 }

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -69,6 +69,7 @@ type CustomLauncherConfig struct {
 	Env                     map[string]string          `yaml:"env"`
 	Experimental            ExperimentalLauncherConfig `yaml:"experimental"`
 	DisableContainerSupport bool                       `yaml:"dangerousDisableContainerSupport"`
+	HeapPercentage          *float64                   `yaml:"heapPercentage" validate:"gt=0,lte=100"`
 }
 
 type ExperimentalLauncherConfig struct {

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -299,6 +299,7 @@ jvmOpts:
   - jvmOpt1
   - jvmOpt2
 dangerousDisableContainerSupport: true
+heapPercentage: 75
 `,
 			want: PrimaryCustomLauncherConfig{
 				VersionedConfig: VersionedConfig{
@@ -310,6 +311,7 @@ dangerousDisableContainerSupport: true
 					},
 					JvmOpts:                 []string{"jvmOpt1", "jvmOpt2"},
 					DisableContainerSupport: true,
+					HeapPercentage:          &[]float64{75}[0],
 					Experimental:            ExperimentalLauncherConfig{},
 				},
 			},

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -312,7 +312,7 @@ heapPercentage: 75
 					},
 					JvmOpts:                 []string{"jvmOpt1", "jvmOpt2"},
 					DisableContainerSupport: true,
-					HeapPercentage:          &[]float64{75}[0],
+					HeapPercentage:          toPointer(75.0),
 					Experimental:            ExperimentalLauncherConfig{},
 				},
 			},
@@ -511,4 +511,8 @@ subProcesses:
 		assert.Regexp(t, currCase.msg, err.Error(), "Case %d: %s had the wrong error message", i, currCase.name)
 	}
 
+}
+
+func toPointer[T any](t T) *T {
+	return &t
 }

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -188,6 +188,7 @@ jvmOpts:
 					},
 					JvmOpts:                 []string{"jvmOpt1", "jvmOpt2"},
 					DisableContainerSupport: false,
+					HeapPercentage:          nil,
 					Experimental:            ExperimentalLauncherConfig{},
 				},
 			},

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -289,7 +289,7 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 			// Also, when the memory limit is unusually high (defined to be over 1TB), we revert to the
 			// percentage-based heap sizing. This is to handle the edge case where the cgroups memory limit is set
 			// to be an arbitrary large value.
-			combinedJvmOpts = filterHeapSizeArgs(combinedJvmOpts)
+			combinedJvmOpts = filterHeapSizeArgs(combinedJvmOpts, customConfig.HeapPercentage)
 		} else {
 			combinedJvmOpts = jvmOptsWithUpdatedHeapSizeArgs
 		}
@@ -307,7 +307,7 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 	return combinedJvmOpts
 }
 
-func filterHeapSizeArgs(args []string) []string {
+func filterHeapSizeArgs(args []string, heapPercentage *float64) []string {
 	var filtered []string
 	var hasMaxRAMPercentage, hasInitialRAMPercentage bool
 	for _, arg := range args {
@@ -323,8 +323,12 @@ func filterHeapSizeArgs(args []string) []string {
 	}
 
 	if !hasInitialRAMPercentage && !hasMaxRAMPercentage {
-		filtered = append(filtered, "-XX:InitialRAMPercentage=75.0")
-		filtered = append(filtered, "-XX:MaxRAMPercentage=75.0")
+		percentage := 75.0
+		if heapPercentage != nil {
+			percentage = *heapPercentage
+		}
+		filtered = append(filtered, fmt.Sprintf("-XX:InitialRAMPercentage=%.1f", percentage))
+		filtered = append(filtered, fmt.Sprintf("-XX:MaxRAMPercentage=%.1f", percentage))
 	}
 	return filtered
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -402,7 +402,7 @@ func ComputeJVMHeapSizeInBytes(hostProcessorCount int, cgroupMemoryLimitInBytes 
 	var processorAdjustment = 3 * BytesInMebibyte * float64(hostProcessorCount)
 
 	if heapPercentage != nil {
-		return uint64(*heapPercentage * memoryLimit), nil
+		return uint64(*heapPercentage / 100 * memoryLimit), nil
 	}
 	var computedHeapSize = max(0.5*memoryLimit, 0.75*memoryLimit-processorAdjustment)
 	return uint64(computedHeapSize), nil

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -399,11 +399,12 @@ func ComputeJVMHeapSizeInBytes(hostProcessorCount int, cgroupMemoryLimitInBytes 
 		return 0, errors.New("cgroups memory limit is unusually high. Not computing JVM heap size")
 	}
 	var memoryLimit = float64(cgroupMemoryLimitInBytes)
-	var processorAdjustment = 3 * BytesInMebibyte * float64(hostProcessorCount)
 
 	if heapPercentage != nil {
 		return uint64(*heapPercentage / 100 * memoryLimit), nil
 	}
+
+	var processorAdjustment = 3 * BytesInMebibyte * float64(hostProcessorCount)
 	var computedHeapSize = max(0.5*memoryLimit, 0.75*memoryLimit-processorAdjustment)
 	return uint64(computedHeapSize), nil
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -281,7 +281,7 @@ func delim(str string) string {
 func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig, logger io.WriteCloser) []string {
 	if isEnvVarSet("CONTAINER") && !customConfig.DisableContainerSupport && !hasMaxRAMOverride(combinedJvmOpts) {
 		_, _ = fmt.Fprintln(logger, "Container support enabled")
-		jvmOptsWithUpdatedHeapSizeArgs, err := filterHeapSizeArgsV2(combinedJvmOpts)
+		jvmOptsWithUpdatedHeapSizeArgs, err := filterHeapSizeArgsV2(combinedJvmOpts, customConfig.HeapPercentage)
 		if err != nil {
 			// When we fail to get the memory limit from the cgroups files, fallback to using percentage-based heap
 			// sizing. While this method doesn't take into account the per-processor memory offset, it is supported
@@ -329,7 +329,7 @@ func filterHeapSizeArgs(args []string) []string {
 	return filtered
 }
 
-func filterHeapSizeArgsV2(args []string) ([]string, error) {
+func filterHeapSizeArgsV2(args []string, heapPercentage *float64) ([]string, error) {
 	var filtered []string
 	var hasMaxRAMPercentage, hasInitialRAMPercentage bool
 	for _, arg := range args {
@@ -353,7 +353,7 @@ func filterHeapSizeArgsV2(args []string) ([]string, error) {
 		if err != nil {
 			return filtered, errors.Wrap(err, "failed to get cgroup memory limit")
 		}
-		jvmHeapSizeInBytes, err := ComputeJVMHeapSizeInBytes(runtime.NumCPU(), cgroupMemoryLimitInBytes)
+		jvmHeapSizeInBytes, err := ComputeJVMHeapSizeInBytes(runtime.NumCPU(), cgroupMemoryLimitInBytes, heapPercentage)
 		if err != nil {
 			return filtered, errors.New("cgroups memory limit is unusually high. Not setting JVM heap size options")
 		}
@@ -388,14 +388,18 @@ func isInitialRAMPercentage(arg string) bool {
 	return strings.HasPrefix(arg, "-XX:InitialRAMPercentage=")
 }
 
-// ComputeJVMHeapSizeInBytes Compute the heap size to be 75% of the heap minus 3mb per processor, with a minimum value
-// of 50% of the heap.
-func ComputeJVMHeapSizeInBytes(hostProcessorCount int, cgroupMemoryLimitInBytes uint64) (uint64, error) {
+// ComputeJVMHeapSizeInBytes By default, compute the heap size to be 75% of the heap minus 3mb per processor, with a minimum value
+// of 50% of the heap. If heapPercentage is provided, use that percentage instead with no processor adjustment.
+func ComputeJVMHeapSizeInBytes(hostProcessorCount int, cgroupMemoryLimitInBytes uint64, heapPercentage *float64) (uint64, error) {
 	if cgroupMemoryLimitInBytes > 1_000_000*BytesInMebibyte {
 		return 0, errors.New("cgroups memory limit is unusually high. Not computing JVM heap size")
 	}
 	var memoryLimit = float64(cgroupMemoryLimitInBytes)
 	var processorAdjustment = 3 * BytesInMebibyte * float64(hostProcessorCount)
+
+	if heapPercentage != nil {
+		return uint64(*heapPercentage * memoryLimit), nil
+	}
 	var computedHeapSize = max(0.5*memoryLimit, 0.75*memoryLimit-processorAdjustment)
 	return uint64(computedHeapSize), nil
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Overriding ``-XX:MaxRAMPercentage=`` and ``-XX:InitialRAMPercentage=`` to the same value does not guarantee that the heap will not shrink. This is different behavior than setting  ``-Xmx`` and ``-Xms``  to the same value.

The default go-java-launcher behavior adjusts the heap size based on the number of processors, resulting in ``-Xmx`` and ``-Xms`` both being set to the same value. The new `heapPercentage` configuration allows services to override the default 75% value while also preventing heap shrinking. 

Note the new `heapPercentage` does not apply the per-processor adjustment. It is assumed anyone overriding this can account for this themselves. 


More detail: 
``-Xms`` sets the minimum heap size. There is no equivalent for `RAMPercentage` style JVM options (note that while `MinRAMPercentage` does exist, it has a confusing name and instead controls the max RAM percentage at memory sizes under ~200MB). 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

