### PR TITLE
Future proof graal anchor link. Default nativeImageExecutablePath.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ experimental:
   executionMode: native
 ```
 
-This requires a native image executable to be available at the path specified by `nativeImageExecutablePath`, which defaults to `service/bin/native-image`.
+This requires a native image executable to be available at the path specified by `nativeImageExecutablePath`, which defaults to `service/bin/native-executable`.
 
 Not all JVM options are supported by native image, so go-java-launcher will attempt to copy over applicable options from `jvmOpts` to the native image executable. The list of respected options is in [AllowedNativeImageJVMOptions](https://github.com/palantir/go-java-launcher/blob/develop/launchlib/native.go).
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ dangerousDisableContainerSupport: true
 Alternatively, the presence of ``-XX:MaxRAM=`` prefix in either static or custom jvm opts will also disable this
 behavior.
 
-### [Experimental] Graal Native Image support
+### Graal Native Image support
 
 > [!WARNING] 
 > Support for native images is experimental and may be either removed or promoted in the future. Use at your own risk.

--- a/README.md
+++ b/README.md
@@ -194,10 +194,9 @@ Go-java-launcher supports running GraalVM Native Images. For example:
 ```yaml
 experimental:
   executionMode: native
-  nativeImageExecutablePath: service/bin/<native-image-executable>
 ```
 
-This requires a native image executable to be available at the specified path.
+This requires a native image executable to be available at the path specified by `nativeImageExecutablePath`, which defaults to `service/bin/native-image`.
 
 Not all JVM options are supported by native image, so go-java-launcher will attempt to copy over applicable options from `jvmOpts` to the native image executable. The list of respected options is in [AllowedNativeImageJVMOptions](https://github.com/palantir/go-java-launcher/blob/develop/launchlib/native.go).
 

--- a/changelog/@unreleased/pr-585.v2.yml
+++ b/changelog/@unreleased/pr-585.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Future proof graal anchor link
+  links:
+  - https://github.com/palantir/go-java-launcher/pull/585

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -33,7 +33,7 @@ const (
 	// ExecPathBlackListRegex matches characters disallowed in paths we allow to be passed to exec()
 	ExecPathBlackListRegex           = `[^\w.\/_\-]`
 	BytesInMebibyte                  = 1048576
-	defaultNativeImageExecutablePath = "service/bin/native-image"
+	defaultNativeImageExecutablePath = "service/bin/native-executable"
 )
 
 type ServiceCmds struct {

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -31,8 +31,9 @@ const (
 	TemplateDelimsOpen  = "{{"
 	TemplateDelimsClose = "}}"
 	// ExecPathBlackListRegex matches characters disallowed in paths we allow to be passed to exec()
-	ExecPathBlackListRegex = `[^\w.\/_\-]`
-	BytesInMebibyte        = 1048576
+	ExecPathBlackListRegex           = `[^\w.\/_\-]`
+	BytesInMebibyte                  = 1048576
+	defaultNativeImageExecutablePath = "service/bin/native-image"
 )
 
 type ServiceCmds struct {
@@ -93,7 +94,11 @@ func compileCmdFromConfig(
 
 		// Handle experimental nativeImage execution mode before standard processing
 		if customConfig.Experimental.ExecutionMode == ExecutionModeNative {
-			executable, executableErr = verifyPathIsSafeForExec(customConfig.Experimental.NativeImageExecutablePath)
+			nativeImageExecutablePath := customConfig.Experimental.NativeImageExecutablePath
+			if nativeImageExecutablePath == "" {
+				nativeImageExecutablePath = defaultNativeImageExecutablePath
+			}
+			executable, executableErr = verifyPathIsSafeForExec(nativeImageExecutablePath)
 			if executableErr != nil {
 				return nil, executableErr
 			}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Future proof graal anchor link.

Default nativeImageExecutablePath to `service/bin/native-executable`
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Future proof graal anchor link. Default nativeImageExecutablePath.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

