### PR TITLE
Add experimental heap size option

### DIFF
--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -92,7 +92,8 @@ type ExperimentalLauncherConfig struct {
 	// EnablePeriodicGC enables periodic GC to return unused memory to the OS.
 	// Only effective when shrinkable heap is enabled (MaxHeapSize != MinHeapSize).
 	// When enabled, adds -XX:G1PeriodicGCInterval for the G1 collector.
-	// ZGC has built-in uncommit behavior enabled by default, so no flag is needed.
+	// Note: This flag is G1-specific and will be ignored (or error) on other collectors like ZGC.
+	// ZGC has built-in uncommit behavior enabled by default, so no additional flag is needed.
 	EnablePeriodicGC bool `yaml:"enablePeriodicGC,omitempty"`
 	// PeriodicGCIntervalMs sets the periodic GC interval in milliseconds.
 	// Only used when EnablePeriodicGC is true. Defaults to 300000 (5 minutes).

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -78,13 +78,25 @@ type ExperimentalLauncherConfig struct {
 	// NativeImageArguments specifies additional arguments that will be passed to the executable when running in native execution mode.
 	NativeImageArguments      []string `yaml:"nativeImageArguments"`
 	NativeImageExecutablePath string   `yaml:"nativeImageExecutablePath"`
-	// ShrinkableHeapMaxSize sets an explicit max heap size (e.g., "2g", "512m") and enables heap shrinking.
-	// When set: -Xmx is set to this value, -Xms is set to 25% of this value, AlwaysPreTouch is disabled,
-	// and G1PeriodicGCInterval is set to 10 minutes to periodically return unused memory to the OS.
-	// This is intended for memory-oversubscribed environments where the container memory limit exceeds the request.
+	// MaxHeapSize sets an explicit max heap size (e.g., "2g", "512m").
+	// When MaxHeapSize is set without MinHeapSize, MinHeapSize defaults to MaxHeapSize (no shrinking).
+	// When MaxHeapSize and MinHeapSize are both set to different values, heap shrinking is enabled:
+	// AlwaysPreTouch is disabled to allow the JVM to return memory to the OS.
 	// Takes precedence over heapPercentage when set.
 	// Note: This option has no effect in native image execution mode.
-	ShrinkableHeapMaxSize string `yaml:"shrinkableHeapMaxSize,omitempty"`
+	MaxHeapSize string `yaml:"maxHeapSize,omitempty"`
+	// MinHeapSize sets the minimum heap size (e.g., "512m", "1g").
+	// Requires MaxHeapSize to also be set. If MinHeapSize > MaxHeapSize, an error is returned.
+	// When different from MaxHeapSize, enables heap shrinking behavior.
+	MinHeapSize string `yaml:"minHeapSize,omitempty"`
+	// EnablePeriodicGC enables periodic GC to return unused memory to the OS.
+	// Only effective when shrinkable heap is enabled (MaxHeapSize != MinHeapSize).
+	// When enabled, adds -XX:G1PeriodicGCInterval for the G1 collector.
+	// ZGC has built-in uncommit behavior enabled by default, so no flag is needed.
+	EnablePeriodicGC bool `yaml:"enablePeriodicGC,omitempty"`
+	// PeriodicGCIntervalMs sets the periodic GC interval in milliseconds.
+	// Only used when EnablePeriodicGC is true. Defaults to 300000 (5 minutes).
+	PeriodicGCIntervalMs *uint64 `yaml:"periodicGCIntervalMs,omitempty"`
 }
 
 type PrimaryCustomLauncherConfig struct {

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -78,6 +78,13 @@ type ExperimentalLauncherConfig struct {
 	// NativeImageArguments specifies additional arguments that will be passed to the executable when running in native execution mode.
 	NativeImageArguments      []string `yaml:"nativeImageArguments"`
 	NativeImageExecutablePath string   `yaml:"nativeImageExecutablePath"`
+	// ShrinkableHeapMaxSize sets an explicit max heap size (e.g., "2g", "512m") and enables heap shrinking.
+	// When set: -Xmx is set to this value, -Xms is set to 25% of this value, AlwaysPreTouch is disabled,
+	// and G1PeriodicGCInterval is set to 10 minutes to periodically return unused memory to the OS.
+	// This is intended for memory-oversubscribed environments where the container memory limit exceeds the request.
+	// Takes precedence over heapPercentage when set.
+	// Note: This option has no effect in native image execution mode.
+	ShrinkableHeapMaxSize string `yaml:"shrinkableHeapMaxSize,omitempty"`
 }
 
 type PrimaryCustomLauncherConfig struct {

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -35,8 +35,7 @@ const (
 	ExecPathBlackListRegex           = `[^\w.\/_\-]`
 	BytesInMebibyte                  = 1048576
 	defaultNativeImageExecutablePath = "service/bin/native-executable"
-	shrinkableHeapMinFraction        = 0.25   // minHeap = maxHeap * shrinkableHeapMinFraction (25% of max)
-	shrinkableHeapGCIntervalMs       = 600000 // 10 minutes - G1 triggers periodic GC to return memory to OS
+	defaultPeriodicGCIntervalMs      = 300000 // 5 minutes - default interval for periodic GC
 )
 
 type ServiceCmds struct {
@@ -358,7 +357,40 @@ func filterHeapSizeArgs(args []string, heapPercentage *float64) []string {
 func filterHeapSizeArgsV2(args []string, heapPercentage *float64, experimental ExperimentalLauncherConfig) ([]string, error) {
 	var filtered []string
 	var hasMaxRAMPercentage, hasInitialRAMPercentage bool
-	shrinkableHeap := experimental.ShrinkableHeapMaxSize != ""
+
+	// Validate MinHeapSize requires MaxHeapSize
+	if experimental.MinHeapSize != "" && experimental.MaxHeapSize == "" {
+		return nil, errors.New("minHeapSize requires maxHeapSize to be set")
+	}
+
+	// Determine if explicit heap sizes are configured
+	hasExplicitHeapConfig := experimental.MaxHeapSize != ""
+
+	// Parse and validate heap sizes if configured
+	var maxHeapBytes, minHeapBytes uint64
+	var shrinkableHeap bool
+	if hasExplicitHeapConfig {
+		var err error
+		maxHeapBytes, err = ParseMemorySize(experimental.MaxHeapSize)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse maxHeapSize")
+		}
+
+		if experimental.MinHeapSize != "" {
+			minHeapBytes, err = ParseMemorySize(experimental.MinHeapSize)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to parse minHeapSize")
+			}
+			if minHeapBytes > maxHeapBytes {
+				return nil, errors.New("minHeapSize cannot be greater than maxHeapSize")
+			}
+		} else {
+			// If MinHeapSize not set, default to MaxHeapSize (no shrinking)
+			minHeapBytes = maxHeapBytes
+		}
+
+		shrinkableHeap = minHeapBytes != maxHeapBytes
+	}
 
 	for _, arg := range args {
 		// Filter out -Xmx/-Xms
@@ -378,17 +410,23 @@ func filterHeapSizeArgsV2(args []string, heapPercentage *float64, experimental E
 		}
 	}
 
-	// If shrinkableHeapMaxSize is set, use it (takes precedence over heapPercentage)
-	if shrinkableHeap {
-		maxHeapBytes, err := ParseMemorySize(experimental.ShrinkableHeapMaxSize)
-		if err != nil {
-			return filtered, errors.Wrap(err, "failed to parse shrinkableHeapMaxSize")
-		}
-		minHeapBytes := uint64(float64(maxHeapBytes) * shrinkableHeapMinFraction)
+	// If MaxHeapSize is set, use explicit heap sizes (takes precedence over heapPercentage)
+	if hasExplicitHeapConfig {
 		filtered = append(filtered, fmt.Sprintf("-Xms%d", minHeapBytes))
 		filtered = append(filtered, fmt.Sprintf("-Xmx%d", maxHeapBytes))
-		filtered = append(filtered, "-XX:-AlwaysPreTouch")
-		filtered = append(filtered, fmt.Sprintf("-XX:G1PeriodicGCInterval=%d", shrinkableHeapGCIntervalMs))
+
+		if shrinkableHeap {
+			filtered = append(filtered, "-XX:-AlwaysPreTouch")
+
+			// Add periodic GC flag only if EnablePeriodicGC is true
+			if experimental.EnablePeriodicGC {
+				intervalMs := uint64(defaultPeriodicGCIntervalMs)
+				if experimental.PeriodicGCIntervalMs != nil {
+					intervalMs = *experimental.PeriodicGCIntervalMs
+				}
+				filtered = append(filtered, fmt.Sprintf("-XX:G1PeriodicGCInterval=%d", intervalMs))
+			}
+		}
 		return filtered, nil
 	}
 

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -34,6 +35,8 @@ const (
 	ExecPathBlackListRegex           = `[^\w.\/_\-]`
 	BytesInMebibyte                  = 1048576
 	defaultNativeImageExecutablePath = "service/bin/native-executable"
+	shrinkableHeapMinFraction        = 0.25   // minHeap = maxHeap * shrinkableHeapMinFraction (25% of max)
+	shrinkableHeapGCIntervalMs       = 600000 // 10 minutes - G1 triggers periodic GC to return memory to OS
 )
 
 type ServiceCmds struct {
@@ -300,7 +303,7 @@ func delim(str string) string {
 func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig, logger io.WriteCloser) []string {
 	if isEnvVarSet("CONTAINER") && !customConfig.DisableContainerSupport && !hasMaxRAMOverride(combinedJvmOpts) {
 		_, _ = fmt.Fprintln(logger, "Container support enabled")
-		jvmOptsWithUpdatedHeapSizeArgs, err := filterHeapSizeArgsV2(combinedJvmOpts, customConfig.HeapPercentage)
+		jvmOptsWithUpdatedHeapSizeArgs, err := filterHeapSizeArgsV2(combinedJvmOpts, customConfig.HeapPercentage, customConfig.Experimental)
 		if err != nil {
 			// When we fail to get the memory limit from the cgroups files, fallback to using percentage-based heap
 			// sizing. While this method doesn't take into account the per-processor memory offset, it is supported
@@ -352,19 +355,41 @@ func filterHeapSizeArgs(args []string, heapPercentage *float64) []string {
 	return filtered
 }
 
-func filterHeapSizeArgsV2(args []string, heapPercentage *float64) ([]string, error) {
+func filterHeapSizeArgsV2(args []string, heapPercentage *float64, experimental ExperimentalLauncherConfig) ([]string, error) {
 	var filtered []string
 	var hasMaxRAMPercentage, hasInitialRAMPercentage bool
+	shrinkableHeap := experimental.ShrinkableHeapMaxSize != ""
+
 	for _, arg := range args {
-		if !isHeapSizeArg(arg) {
-			filtered = append(filtered, arg)
+		// Filter out -Xmx/-Xms
+		if isHeapSizeArg(arg) {
+			continue
 		}
+		// Filter out AlwaysPreTouch when using shrinkable heap
+		if shrinkableHeap && isAlwaysPreTouch(arg) {
+			continue
+		}
+		filtered = append(filtered, arg)
 
 		if isMaxRAMPercentage(arg) {
 			hasMaxRAMPercentage = true
 		} else if isInitialRAMPercentage(arg) {
 			hasInitialRAMPercentage = true
 		}
+	}
+
+	// If shrinkableHeapMaxSize is set, use it (takes precedence over heapPercentage)
+	if shrinkableHeap {
+		maxHeapBytes, err := ParseMemorySize(experimental.ShrinkableHeapMaxSize)
+		if err != nil {
+			return filtered, errors.Wrap(err, "failed to parse shrinkableHeapMaxSize")
+		}
+		minHeapBytes := uint64(float64(maxHeapBytes) * shrinkableHeapMinFraction)
+		filtered = append(filtered, fmt.Sprintf("-Xms%d", minHeapBytes))
+		filtered = append(filtered, fmt.Sprintf("-Xmx%d", maxHeapBytes))
+		filtered = append(filtered, "-XX:-AlwaysPreTouch")
+		filtered = append(filtered, fmt.Sprintf("-XX:G1PeriodicGCInterval=%d", shrinkableHeapGCIntervalMs))
+		return filtered, nil
 	}
 
 	if !hasInitialRAMPercentage && !hasMaxRAMPercentage {
@@ -409,6 +434,47 @@ func isMaxRAMPercentage(arg string) bool {
 
 func isInitialRAMPercentage(arg string) bool {
 	return strings.HasPrefix(arg, "-XX:InitialRAMPercentage=")
+}
+
+func isAlwaysPreTouch(arg string) bool {
+	return strings.HasPrefix(arg, "-XX:+AlwaysPreTouch")
+}
+
+// ParseMemorySize parses a memory size string in the same format as Java's -Xmx/-Xms flags.
+// Supports suffixes: k/K (kilobytes), m/M (megabytes), g/G (gigabytes), t/T (terabytes).
+// All units are binary (1024-based). No suffix means bytes.
+// Examples: "2g", "512m", "1024k", "1t", "2147483648"
+// Returns the size in bytes.
+func ParseMemorySize(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, errors.New("empty memory size")
+	}
+
+	lower := strings.ToLower(s)
+	multiplier := uint64(1)
+	numStr := s
+
+	if strings.HasSuffix(lower, "t") {
+		multiplier = 1024 * 1024 * 1024 * 1024
+		numStr = s[:len(s)-1]
+	} else if strings.HasSuffix(lower, "g") {
+		multiplier = 1024 * 1024 * 1024
+		numStr = s[:len(s)-1]
+	} else if strings.HasSuffix(lower, "m") {
+		multiplier = 1024 * 1024
+		numStr = s[:len(s)-1]
+	} else if strings.HasSuffix(lower, "k") {
+		multiplier = 1024
+		numStr = s[:len(s)-1]
+	}
+
+	val, err := strconv.ParseUint(strings.TrimSpace(numStr), 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "invalid memory size: %s", s)
+	}
+
+	return val * multiplier, nil
 }
 
 // ComputeJVMHeapSizeInBytes By default, compute the heap size to be 75% of the heap minus 3mb per processor, with a minimum value

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -416,8 +416,6 @@ func filterHeapSizeArgsV2(args []string, heapPercentage *float64, experimental E
 		filtered = append(filtered, fmt.Sprintf("-Xmx%d", maxHeapBytes))
 
 		if shrinkableHeap {
-			filtered = append(filtered, "-XX:-AlwaysPreTouch")
-
 			// Add periodic GC flag only if EnablePeriodicGC is true
 			if experimental.EnablePeriodicGC {
 				intervalMs := uint64(defaultPeriodicGCIntervalMs)

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -446,7 +446,6 @@ func isAlwaysPreTouch(arg string) bool {
 // Examples: "2g", "512m", "1024k", "1t", "2147483648"
 // Returns the size in bytes.
 func ParseMemorySize(s string) (uint64, error) {
-	s = strings.TrimSpace(s)
 	if s == "" {
 		return 0, errors.New("empty memory size")
 	}
@@ -469,7 +468,7 @@ func ParseMemorySize(s string) (uint64, error) {
 		numStr = s[:len(s)-1]
 	}
 
-	val, err := strconv.ParseUint(strings.TrimSpace(numStr), 10, 64)
+	val, err := strconv.ParseUint(numStr, 10, 64)
 	if err != nil {
 		return 0, errors.Wrapf(err, "invalid memory size: %s", s)
 	}

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -234,8 +234,7 @@ func TestParseMemorySize(t *testing.T) {
 		{"512M", 512 * 1024 * 1024, false},
 		{"1024k", 1024 * 1024, false},
 		{"1024K", 1024 * 1024, false},
-		{"1073741824", 1073741824, false},       // raw bytes
-		{" 2g ", 2 * 1024 * 1024 * 1024, false}, // with whitespace
+		{"1073741824", 1073741824, false}, // raw bytes
 		{"", 0, true},
 		{"invalid", 0, true},
 		{"2x", 0, true},

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -260,7 +260,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 		experimental   ExperimentalLauncherConfig
 		wantXms        string
 		wantXmx        string
-		wantNoPreTouch bool
 		wantPeriodicGC bool
 		wantErr        bool
 		wantErrMsg     string
@@ -273,7 +272,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 			},
 			wantXms:        fmt.Sprintf("-Xms%d", 2*1024*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
-			wantNoPreTouch: false,
 			wantPeriodicGC: false,
 		},
 		{
@@ -285,7 +283,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 			},
 			wantXms:        fmt.Sprintf("-Xms%d", 2*1024*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
-			wantNoPreTouch: false,
 			wantPeriodicGC: false,
 		},
 		{
@@ -297,7 +294,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 			},
 			wantXms:        fmt.Sprintf("-Xms%d", 512*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
-			wantNoPreTouch: true,
 			wantPeriodicGC: false,
 		},
 		{
@@ -310,7 +306,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 			},
 			wantXms:        fmt.Sprintf("-Xms%d", 512*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
-			wantNoPreTouch: true,
 			wantPeriodicGC: true,
 		},
 		{
@@ -322,7 +317,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 			},
 			wantXms:        fmt.Sprintf("-Xms%d", 256*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 1024*1024*1024),
-			wantNoPreTouch: true,
 			wantPeriodicGC: false,
 		},
 		{
@@ -334,7 +328,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 			},
 			wantXms:        fmt.Sprintf("-Xms%d", 512*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 1024*1024*1024),
-			wantNoPreTouch: true,
 			wantPeriodicGC: false,
 		},
 		{
@@ -367,7 +360,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 			},
 			wantXms:        fmt.Sprintf("-Xms%d", 512*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
-			wantNoPreTouch: true,
 			wantPeriodicGC: true,
 		},
 	}
@@ -385,13 +377,6 @@ func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 			require.NoError(t, err)
 			assert.Contains(t, result, tc.wantXms)
 			assert.Contains(t, result, tc.wantXmx)
-
-			if tc.wantNoPreTouch {
-				assert.Contains(t, result, "-XX:-AlwaysPreTouch")
-				assert.NotContains(t, result, "-XX:+AlwaysPreTouch")
-			} else {
-				assert.NotContains(t, result, "-XX:-AlwaysPreTouch")
-			}
 
 			if tc.wantPeriodicGC {
 				intervalMs := uint64(300000)

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -221,3 +221,94 @@ func TestCompileCmdNativeExecutionModeHeapPercentage(t *testing.T) {
 
 	assert.Contains(t, cmd.Args, "-XX:MaximumHeapSizePercent=60")
 }
+
+func TestParseMemorySize(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected uint64
+		wantErr  bool
+	}{
+		{"1g", 1024 * 1024 * 1024, false},
+		{"2G", 2 * 1024 * 1024 * 1024, false},
+		{"512m", 512 * 1024 * 1024, false},
+		{"512M", 512 * 1024 * 1024, false},
+		{"1024k", 1024 * 1024, false},
+		{"1024K", 1024 * 1024, false},
+		{"1073741824", 1073741824, false},       // raw bytes
+		{" 2g ", 2 * 1024 * 1024 * 1024, false}, // with whitespace
+		{"", 0, true},
+		{"invalid", 0, true},
+		{"2x", 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := ParseMemorySize(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFilterHeapSizeArgsV2_ShrinkableHeap(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		experimental   ExperimentalLauncherConfig
+		wantXms        string
+		wantXmx        string
+		wantNoPreTouch bool
+	}{
+		{
+			name: "shrinkableHeapMaxSize sets Xms to 25% of Xmx",
+			args: []string{"-Dfoo=bar"},
+			experimental: ExperimentalLauncherConfig{
+				ShrinkableHeapMaxSize: "2g",
+			},
+			wantXms:        fmt.Sprintf("-Xms%d", (2*1024*1024*1024)/4),
+			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
+			wantNoPreTouch: true,
+		},
+		{
+			name: "shrinkableHeapMaxSize filters out existing AlwaysPreTouch",
+			args: []string{"-Dfoo=bar", "-XX:+AlwaysPreTouch"},
+			experimental: ExperimentalLauncherConfig{
+				ShrinkableHeapMaxSize: "1g",
+			},
+			wantXms:        fmt.Sprintf("-Xms%d", (1024*1024*1024)/4),
+			wantXmx:        fmt.Sprintf("-Xmx%d", 1024*1024*1024),
+			wantNoPreTouch: true,
+		},
+		{
+			name: "shrinkableHeapMaxSize filters out existing Xmx/Xms",
+			args: []string{"-Xmx4g", "-Xms2g", "-Dfoo=bar"},
+			experimental: ExperimentalLauncherConfig{
+				ShrinkableHeapMaxSize: "1g",
+			},
+			wantXms:        fmt.Sprintf("-Xms%d", (1024*1024*1024)/4),
+			wantXmx:        fmt.Sprintf("-Xmx%d", 1024*1024*1024),
+			wantNoPreTouch: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := filterHeapSizeArgsV2(tc.args, nil, tc.experimental)
+			require.NoError(t, err)
+
+			assert.Contains(t, result, tc.wantXms)
+			assert.Contains(t, result, tc.wantXmx)
+			if tc.wantNoPreTouch {
+				assert.Contains(t, result, "-XX:-AlwaysPreTouch")
+				assert.NotContains(t, result, "-XX:+AlwaysPreTouch")
+				assert.Contains(t, result, "-XX:G1PeriodicGCInterval=600000")
+			}
+			// Original args should be preserved (except filtered ones)
+			assert.Contains(t, result, "-Dfoo=bar")
+		})
+	}
+}

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -253,7 +253,7 @@ func TestParseMemorySize(t *testing.T) {
 	}
 }
 
-func TestFilterHeapSizeArgsV2_ShrinkableHeap(t *testing.T) {
+func TestFilterHeapSizeArgsV2_MaxMinHeapSize(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           []string
@@ -261,53 +261,169 @@ func TestFilterHeapSizeArgsV2_ShrinkableHeap(t *testing.T) {
 		wantXms        string
 		wantXmx        string
 		wantNoPreTouch bool
+		wantPeriodicGC bool
+		wantErr        bool
+		wantErrMsg     string
 	}{
 		{
-			name: "shrinkableHeapMaxSize sets Xms to 25% of Xmx",
+			name: "maxHeapSize only sets min equal to max (no shrinking)",
 			args: []string{"-Dfoo=bar"},
 			experimental: ExperimentalLauncherConfig{
-				ShrinkableHeapMaxSize: "2g",
+				MaxHeapSize: "2g",
 			},
-			wantXms:        fmt.Sprintf("-Xms%d", (2*1024*1024*1024)/4),
+			wantXms:        fmt.Sprintf("-Xms%d", 2*1024*1024*1024),
+			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
+			wantNoPreTouch: false,
+			wantPeriodicGC: false,
+		},
+		{
+			name: "maxHeapSize and minHeapSize same value (no shrinking)",
+			args: []string{"-Dfoo=bar"},
+			experimental: ExperimentalLauncherConfig{
+				MaxHeapSize: "2g",
+				MinHeapSize: "2g",
+			},
+			wantXms:        fmt.Sprintf("-Xms%d", 2*1024*1024*1024),
+			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
+			wantNoPreTouch: false,
+			wantPeriodicGC: false,
+		},
+		{
+			name: "maxHeapSize and minHeapSize different enables shrinking but no periodic GC",
+			args: []string{"-Dfoo=bar"},
+			experimental: ExperimentalLauncherConfig{
+				MaxHeapSize: "2g",
+				MinHeapSize: "512m",
+			},
+			wantXms:        fmt.Sprintf("-Xms%d", 512*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
 			wantNoPreTouch: true,
+			wantPeriodicGC: false,
 		},
 		{
-			name: "shrinkableHeapMaxSize filters out existing AlwaysPreTouch",
+			name: "shrinkable heap with EnablePeriodicGC adds all GC interval flags",
+			args: []string{"-Dfoo=bar"},
+			experimental: ExperimentalLauncherConfig{
+				MaxHeapSize:      "2g",
+				MinHeapSize:      "512m",
+				EnablePeriodicGC: true,
+			},
+			wantXms:        fmt.Sprintf("-Xms%d", 512*1024*1024),
+			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
+			wantNoPreTouch: true,
+			wantPeriodicGC: true,
+		},
+		{
+			name: "shrinkable heap filters out existing AlwaysPreTouch",
 			args: []string{"-Dfoo=bar", "-XX:+AlwaysPreTouch"},
 			experimental: ExperimentalLauncherConfig{
-				ShrinkableHeapMaxSize: "1g",
+				MaxHeapSize: "1g",
+				MinHeapSize: "256m",
 			},
-			wantXms:        fmt.Sprintf("-Xms%d", (1024*1024*1024)/4),
+			wantXms:        fmt.Sprintf("-Xms%d", 256*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 1024*1024*1024),
 			wantNoPreTouch: true,
+			wantPeriodicGC: false,
 		},
 		{
-			name: "shrinkableHeapMaxSize filters out existing Xmx/Xms",
+			name: "explicit heap sizes filter out existing Xmx/Xms",
 			args: []string{"-Xmx4g", "-Xms2g", "-Dfoo=bar"},
 			experimental: ExperimentalLauncherConfig{
-				ShrinkableHeapMaxSize: "1g",
+				MaxHeapSize: "1g",
+				MinHeapSize: "512m",
 			},
-			wantXms:        fmt.Sprintf("-Xms%d", (1024*1024*1024)/4),
+			wantXms:        fmt.Sprintf("-Xms%d", 512*1024*1024),
 			wantXmx:        fmt.Sprintf("-Xmx%d", 1024*1024*1024),
 			wantNoPreTouch: true,
+			wantPeriodicGC: false,
+		},
+		{
+			name: "minHeapSize without maxHeapSize returns error",
+			args: []string{"-Dfoo=bar"},
+			experimental: ExperimentalLauncherConfig{
+				MinHeapSize: "512m",
+			},
+			wantErr:    true,
+			wantErrMsg: "minHeapSize requires maxHeapSize to be set",
+		},
+		{
+			name: "minHeapSize greater than maxHeapSize returns error",
+			args: []string{"-Dfoo=bar"},
+			experimental: ExperimentalLauncherConfig{
+				MaxHeapSize: "512m",
+				MinHeapSize: "2g",
+			},
+			wantErr:    true,
+			wantErrMsg: "minHeapSize cannot be greater than maxHeapSize",
+		},
+		{
+			name: "custom PeriodicGCIntervalMs",
+			args: []string{"-Dfoo=bar"},
+			experimental: ExperimentalLauncherConfig{
+				MaxHeapSize:          "2g",
+				MinHeapSize:          "512m",
+				EnablePeriodicGC:     true,
+				PeriodicGCIntervalMs: ptrUint64(600000),
+			},
+			wantXms:        fmt.Sprintf("-Xms%d", 512*1024*1024),
+			wantXmx:        fmt.Sprintf("-Xmx%d", 2*1024*1024*1024),
+			wantNoPreTouch: true,
+			wantPeriodicGC: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := filterHeapSizeArgsV2(tc.args, nil, tc.experimental)
-			require.NoError(t, err)
 
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
 			assert.Contains(t, result, tc.wantXms)
 			assert.Contains(t, result, tc.wantXmx)
+
 			if tc.wantNoPreTouch {
 				assert.Contains(t, result, "-XX:-AlwaysPreTouch")
 				assert.NotContains(t, result, "-XX:+AlwaysPreTouch")
-				assert.Contains(t, result, "-XX:G1PeriodicGCInterval=600000")
+			} else {
+				assert.NotContains(t, result, "-XX:-AlwaysPreTouch")
 			}
+
+			if tc.wantPeriodicGC {
+				intervalMs := uint64(300000)
+				if tc.experimental.PeriodicGCIntervalMs != nil {
+					intervalMs = *tc.experimental.PeriodicGCIntervalMs
+				}
+				assert.Contains(t, result, fmt.Sprintf("-XX:G1PeriodicGCInterval=%d", intervalMs))
+			} else {
+				assert.NotContains(t, result, "-XX:G1PeriodicGCInterval=")
+			}
+
 			// Original args should be preserved (except filtered ones)
 			assert.Contains(t, result, "-Dfoo=bar")
 		})
 	}
+}
+
+func TestFilterHeapSizeArgsV2_MaxHeapSizePrecedence(t *testing.T) {
+	// MaxHeapSize should take precedence over heapPercentage
+	heapPercentage := 50.0
+	experimental := ExperimentalLauncherConfig{
+		MaxHeapSize: "1g",
+	}
+
+	result, err := filterHeapSizeArgsV2([]string{"-Dfoo=bar"}, &heapPercentage, experimental)
+	require.NoError(t, err)
+
+	// Should use MaxHeapSize, not heapPercentage
+	assert.Contains(t, result, fmt.Sprintf("-Xms%d", 1024*1024*1024))
+	assert.Contains(t, result, fmt.Sprintf("-Xmx%d", 1024*1024*1024))
+}
+
+func ptrUint64(v uint64) *uint64 {
+	return &v
 }

--- a/launchlib/native.go
+++ b/launchlib/native.go
@@ -55,6 +55,7 @@ func getNativeArgsFromJVMOpts(jvmOpts []string) []string {
 }
 
 // getNativeArgs filters out any heap-related options that are not supported by the current mode (container mode enabled/disabled), and adds -XX:MaximumHeapSizePercent using heapPercentage if applicable
+// Note: shrinkableHeapMaxSize is not supported for native images.
 func getNativeArgs(nativeArgs []string, customConfig *CustomLauncherConfig) []string {
 	var filteredArgs []string
 


### PR DESCRIPTION
## Summary

Adds new experimental config options for explicit heap size control with optional heap shrinking behavior.

**New config options** (in `experimental` section):
- `maxHeapSize`: Sets the max heap size (e.g., `"2g"`, `"512m"`). Takes precedence over `heapPercentage`.
- `minHeapSize`: Sets the min heap size. Requires `maxHeapSize` to be set. If omitted, defaults to `maxHeapSize` (no shrinking).
- `enablePeriodicGC`: When `true` and shrinkable heap is enabled, adds `-XX:G1PeriodicGCInterval` to trigger periodic GC.
- `periodicGCIntervalMs`: Custom interval for periodic GC (default: 300000ms / 5 minutes).

**Behavior:**
- When `maxHeapSize` is set alone or `minHeapSize == maxHeapSize`: fixed heap size, no shrinking.
- When `minHeapSize < maxHeapSize`: shrinkable heap is enabled:
  - `-XX:+AlwaysPreTouch` is filtered out if present in jvmOpts (allows heap to not be fully committed upfront)
  - If `enablePeriodicGC: true`, `-XX:G1PeriodicGCInterval` is added (G1-specific)

This allows the JVM to dynamically shrink its heap when memory pressure increases on the node. The periodic GC flag is opt-in and G1-specific (ZGC has built-in uncommit behavior).

**Example config:**
```yaml
experimental:
  maxHeapSize: "4g"
  minHeapSize: "1g"
  enablePeriodicGC: true
  periodicGCIntervalMs: 600000  # optional, defaults to 300000
```

**Note:** These options have no effect in native image execution mode.