### PR TITLE
Manually bump `external-publish-plugin` to 1.35.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.33.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.35.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.18.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:5.0.0'
         classpath 'com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.8.0'


### PR DESCRIPTION
## Before this PR
Gradle-git-version was upgraded to 5.0.0, this contained a break (a regrettable decision now), but versions of external-publish-plugin used the class that was deleted. However, the [PR](https://github.com/palantir/go-java-launcher/pull/668) which bumped it did *not* fail, ~which is the confusing part~. So when trying to do any sort of configuration, it will fail because it can't find the class. Thus getting into a catch-22, can't run gradle to use roomba to upgrade and the current state is also broken.

Okay, I've understood it now, the steps that run for PR builds, do not invoke gradle at all, just godel stuff. So it never triggered that code path. Gradle only runs in the publish step and as such runs into this.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

Manually just bumped it.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

