### PR TITLE
Add offHeapMemoryBytes config for off-heap memory reservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,32 @@ Developers can specify both ``MaxRAMPercentage|InitialRAMPercentage``
 together with ``-Xmx|-Xms`` overrides safely: ``-Xmx/-Xms`` overrides ALWAYS take precedence and will be filtered out
 when running inside a container, as per logic detailed above.
 
+### Off-heap memory reservation
+
+Services that allocate significant off-heap memory (e.g., Apache Arrow buffers) can set `offHeapMemoryBytes` in
+`launcher-custom.yml` to subtract a fixed reservation from the container memory limit before computing the JVM heap
+size. This allows services to use the default 75% heap percentage while accounting for known off-heap memory usage.
+
+For example, a service with a 2 GiB Arrow allocation limit:
+
+```yaml
+configType: java
+offHeapMemoryBytes: 2147483648
+```
+
+With this configuration, the heap is computed as:
+
+```
+heap = (containerMemoryLimit - offHeapMemoryBytes) * heapPercentage
+```
+
+where `heapPercentage` defaults to 75% (with per-processor adjustment) if not explicitly set. This is preferable to
+manually setting a lower `heapPercentage`, because the heap size adapts correctly when the container memory limit
+changes.
+
+`offHeapMemoryBytes` only takes effect in the cgroup-based heap sizing path (container mode with readable cgroup memory
+limits). If cgroup detection falls back to percentage-based sizing, a warning is logged.
+
 ### Disabling container support
 
 This behavior can be disabled by setting the following in ``launcher-custom.yml``:

--- a/integration_test/go_java_launcher_integration_test.go
+++ b/integration_test/go_java_launcher_integration_test.go
@@ -186,6 +186,7 @@ func TestComputeJVMHeapSize(t *testing.T) {
 		numHostProcessors   int
 		memoryLimit         uint64
 		heapPercentage      *float64
+		offHeapMemoryBytes  *uint64
 		expectedMaxHeapSize uint64
 	}{
 		{
@@ -219,9 +220,41 @@ func TestComputeJVMHeapSize(t *testing.T) {
 			heapPercentage:      toPointer(10.0),
 			expectedMaxHeapSize: 1 * launchlib.BytesInMebibyte,
 		},
+		{
+			name:                "offHeapMemoryBytes subtracts from memory before percentage",
+			numHostProcessors:   1,
+			memoryLimit:         100 * launchlib.BytesInMebibyte,
+			heapPercentage:      toPointer(75.0),
+			offHeapMemoryBytes:  toPointer[uint64](20 * launchlib.BytesInMebibyte),
+			expectedMaxHeapSize: 60 * launchlib.BytesInMebibyte, // 75% * (100 - 20) = 60
+		},
+		{
+			name:                "offHeapMemoryBytes with default percentage and processor adjustment",
+			numHostProcessors:   1,
+			memoryLimit:         100 * launchlib.BytesInMebibyte,
+			heapPercentage:      nil,
+			offHeapMemoryBytes:  toPointer[uint64](20 * launchlib.BytesInMebibyte),
+			expectedMaxHeapSize: 57 * launchlib.BytesInMebibyte, // 75% * (100 - 20) - 3*1 = 57
+		},
+		{
+			name:                "offHeapMemoryBytes larger than memory yields zero heap",
+			numHostProcessors:   1,
+			memoryLimit:         10 * launchlib.BytesInMebibyte,
+			heapPercentage:      toPointer(75.0),
+			offHeapMemoryBytes:  toPointer[uint64](20 * launchlib.BytesInMebibyte),
+			expectedMaxHeapSize: 0,
+		},
+		{
+			name:                "nil offHeapMemoryBytes preserves existing behavior",
+			numHostProcessors:   1,
+			memoryLimit:         16 * launchlib.BytesInMebibyte,
+			heapPercentage:      nil,
+			offHeapMemoryBytes:  nil,
+			expectedMaxHeapSize: 9 * launchlib.BytesInMebibyte, // 75% * 16 - 3*1 = 9
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			heapSizeInBytes := launchlib.ComputeJVMHeapSizeInBytes(tc.numHostProcessors, tc.memoryLimit, tc.heapPercentage)
+			heapSizeInBytes := launchlib.ComputeJVMHeapSizeInBytes(tc.numHostProcessors, tc.memoryLimit, tc.heapPercentage, tc.offHeapMemoryBytes)
 			assert.Equal(t, heapSizeInBytes, tc.expectedMaxHeapSize)
 		})
 	}

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -70,6 +70,11 @@ type CustomLauncherConfig struct {
 	Experimental            ExperimentalLauncherConfig `yaml:"experimental"`
 	DisableContainerSupport bool                       `yaml:"dangerousDisableContainerSupport"`
 	HeapPercentage          *float64                   `yaml:"heapPercentage" validate:"gt=0,lte=100"`
+	// OffHeapMemoryBytes specifies a fixed off-heap memory reservation (in bytes) that should be subtracted from the
+	// container memory limit before computing the JVM heap size. This is useful for services that allocate significant
+	// off-heap memory (e.g., Apache Arrow buffers) that the launcher's heap sizing would otherwise not account for.
+	// Only takes effect in container mode (CONTAINER env var set and dangerousDisableContainerSupport is false).
+	OffHeapMemoryBytes *uint64 `yaml:"offHeapMemoryBytes"`
 }
 
 type ExperimentalLauncherConfig struct {

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -306,15 +306,21 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 			// sizing. While this method doesn't take into account the per-processor memory offset, it is supported
 			// by all platforms using Java.
 			_, _ = fmt.Fprintf(logger, "Failed to get cgroup memory limit, falling back to percentage-based heap sizing: %v\n", err)
+			if customConfig.OffHeapMemoryBytes != nil {
+				_, _ = fmt.Fprintln(logger, "WARNING: offHeapMemoryBytes is set but cannot be applied with percentage-based heap sizing fallback")
+			}
 			return filterHeapSizeArgs(combinedJvmOpts, customConfig.HeapPercentage)
 		}
 		if cgroupMemoryLimitInBytes > 1_000_000*BytesInMebibyte {
 			// When the memory limit is unusually high (defined to be over 1TB), revert to percentage-based heap
 			// sizing. This handles the edge case where the cgroups memory limit is set to an arbitrary large value.
 			_, _ = fmt.Fprintf(logger, "Cgroup memory limit unusually high (%d bytes), falling back to percentage-based heap sizing\n", cgroupMemoryLimitInBytes)
+			if customConfig.OffHeapMemoryBytes != nil {
+				_, _ = fmt.Fprintln(logger, "WARNING: offHeapMemoryBytes is set but cannot be applied with percentage-based heap sizing fallback")
+			}
 			return filterHeapSizeArgs(combinedJvmOpts, customConfig.HeapPercentage)
 		}
-		return filterHeapSizeArgsV2(combinedJvmOpts, customConfig.HeapPercentage, cgroupMemoryLimitInBytes, customConfig.Experimental.AllowHeapShrink)
+		return filterHeapSizeArgsV2(combinedJvmOpts, customConfig.HeapPercentage, cgroupMemoryLimitInBytes, customConfig.Experimental.AllowHeapShrink, customConfig.OffHeapMemoryBytes)
 	}
 
 	if isEnvVarSet("CONTAINER") {
@@ -366,7 +372,7 @@ func getCGroupMemoryLimitInBytes() (uint64, error) {
 	return cgroupMemoryLimitInBytes, nil
 }
 
-func filterHeapSizeArgsV2(args []string, heapPercentage *float64, cgroupMemoryLimitInBytes uint64, allowHeapShrink bool) []string {
+func filterHeapSizeArgsV2(args []string, heapPercentage *float64, cgroupMemoryLimitInBytes uint64, allowHeapShrink bool, offHeapMemoryBytes *uint64) []string {
 	var filtered []string
 	var hasMaxRAMPercentage, hasInitialRAMPercentage bool
 	for _, arg := range args {
@@ -386,7 +392,7 @@ func filterHeapSizeArgsV2(args []string, heapPercentage *float64, cgroupMemoryLi
 	}
 
 	if !hasInitialRAMPercentage && !hasMaxRAMPercentage {
-		jvmHeapSizeInBytes := ComputeJVMHeapSizeInBytes(runtime.NumCPU(), cgroupMemoryLimitInBytes, heapPercentage)
+		jvmHeapSizeInBytes := ComputeJVMHeapSizeInBytes(runtime.NumCPU(), cgroupMemoryLimitInBytes, heapPercentage, offHeapMemoryBytes)
 		if !allowHeapShrink {
 			filtered = append(filtered, fmt.Sprintf("-Xms%d", jvmHeapSizeInBytes))
 		}
@@ -426,8 +432,15 @@ func isInitialRAMPercentage(arg string) bool {
 
 // ComputeJVMHeapSizeInBytes By default, compute the heap size to be 75% of the heap minus 3mb per processor, with a minimum value
 // of 50% of the heap. If heapPercentage is provided, use that percentage instead with no processor adjustment.
-func ComputeJVMHeapSizeInBytes(hostProcessorCount int, cgroupMemoryLimitInBytes uint64, heapPercentage *float64) uint64 {
+// If offHeapMemoryBytes is provided, it is subtracted from the memory limit before computing the heap size.
+func ComputeJVMHeapSizeInBytes(hostProcessorCount int, cgroupMemoryLimitInBytes uint64, heapPercentage *float64, offHeapMemoryBytes *uint64) uint64 {
 	var memoryLimit = float64(cgroupMemoryLimitInBytes)
+	if offHeapMemoryBytes != nil {
+		memoryLimit -= float64(*offHeapMemoryBytes)
+		if memoryLimit < 0 {
+			memoryLimit = 0
+		}
+	}
 
 	if heapPercentage != nil {
 		return uint64(*heapPercentage / 100 * memoryLimit)

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -254,7 +254,6 @@ func TestFilterHeapSizeArgsV2(t *testing.T) {
 	}
 }
 
-
 func TestCompileCmdNativeExecutionMode(t *testing.T) {
 	// Create a temporary executable file
 	tmpFile, err := os.CreateTemp("", "my-service-native")

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -152,13 +152,14 @@ func TestMkdirChecksDirectorySyntax(t *testing.T) {
 
 func TestFilterHeapSizeArgsV2(t *testing.T) {
 	tests := []struct {
-		name            string
-		args            []string
-		cgroupMemory    uint64
-		heapPercentage  *float64
-		allowHeapShrink bool
-		wantContains    []string
-		wantNotContains []string
+		name               string
+		args               []string
+		cgroupMemory       uint64
+		heapPercentage     *float64
+		allowHeapShrink    bool
+		offHeapMemoryBytes *uint64
+		wantContains       []string
+		wantNotContains    []string
 	}{
 		{
 			name:            "allowHeapShrink false sets both Xms and Xmx",
@@ -216,10 +217,33 @@ func TestFilterHeapSizeArgsV2(t *testing.T) {
 				fmt.Sprintf("-Xmx%d", 1*BytesInMebibyte),
 			},
 		},
+		{
+			name:               "offHeapMemoryBytes subtracts from container memory",
+			args:               []string{"-Dfoo=bar"},
+			cgroupMemory:       10 * BytesInMebibyte,
+			heapPercentage:     toPointer(50.0),
+			offHeapMemoryBytes: toPointer[uint64](2 * BytesInMebibyte),
+			// heap = 50% * (10 MiB - 2 MiB) = 4 MiB
+			wantContains: []string{
+				fmt.Sprintf("-Xms%d", 4*BytesInMebibyte),
+				fmt.Sprintf("-Xmx%d", 4*BytesInMebibyte),
+			},
+		},
+		{
+			name:           "nil offHeapMemoryBytes uses full container memory",
+			args:           []string{"-Dfoo=bar"},
+			cgroupMemory:   10 * BytesInMebibyte,
+			heapPercentage: toPointer(50.0),
+			// heap = 50% * 10 MiB = 5 MiB
+			wantContains: []string{
+				fmt.Sprintf("-Xms%d", 5*BytesInMebibyte),
+				fmt.Sprintf("-Xmx%d", 5*BytesInMebibyte),
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := filterHeapSizeArgsV2(tc.args, tc.heapPercentage, tc.cgroupMemory, tc.allowHeapShrink)
+			result := filterHeapSizeArgsV2(tc.args, tc.heapPercentage, tc.cgroupMemory, tc.allowHeapShrink, tc.offHeapMemoryBytes)
 			for _, want := range tc.wantContains {
 				assert.Contains(t, result, want)
 			}
@@ -229,6 +253,7 @@ func TestFilterHeapSizeArgsV2(t *testing.T) {
 		})
 	}
 }
+
 
 func TestCompileCmdNativeExecutionMode(t *testing.T) {
 	// Create a temporary executable file


### PR DESCRIPTION
## Before this PR
Services that have large off-heap memory pools (like Apache Arrow buffers) have only the `heapPercentage` parameter to use and cannot set a good value that works both for large-memory containers and small memory containers.

For example, I have a service that has a 2 GiB off-heap arrow memory pool.

With the default 75% `heapPercentage` this works on large containers but breaks on small containers. For small containers with a 4GiB container memory, the 75% `heapPercentage` works out to a 3GiB heap. But 2+3=5Gib memory can be used, and I get containerOomKills because this exceeds the container's memory.  For large containers with a 96GiB container memory, the 75% works out to 72GiB heap and 2GiB for Arrow, which fits easily in the 96GiB container.

Because of the above, we have lowered our service's `heapPercentage` to 50%. Now this works on small heaps, but wastes a ton of memory on large heaps. Having a 96GiB container where only 48GiB of memory goes to heap means that a lot of memory is wasted.  And even with `heapPercentage` at the lowered value of 50%, this _still_) causes containerOomKills on small heaps. For example, a 3GiB container yields 1.5GiB heap and 2GiB for arrow which sums to 3.5GiB and still causes containerOomKills.

We need more flexibility than just `heapPercentage`

## After this PR
==COMMIT_MSG==
Add offHeapMemoryBytes config for off-heap memory reservation
==COMMIT_MSG==

This PR introduces a new configuration option `offHeapMemoryBytes` that subtracts off a fixed reservation from the container memory before applying the `heapPercentage` value.

Now if we set:
```
heapPercentage: 75
offHeapMemoryBytes: 2GiB
```

then we can work on both large containers and small containers. For a 4GiB container the JVM is launched with (4-2) * .75 => 1.5GiB heap, and wouldn't die from container OOMs because 2 + 1.5 is still < 4.  For a large container of 96GiB we'd now have 70.5GiB for the heap, and have much less waste (compared to the 48GiB heap we have in place now).

With this change, services that have expected large off-heap memory allocations from using common libraries like Apache Arrow or Netty will be able to configure their JVM sizes appropriately to fit within the container.

## Possible downsides?
- one more configuration option. With the upcoming go-java-launcher -> java-java-launcher plan, this would need to be reimplemented in the future java-java-launcher as well
- the name `offHeapMemoryBytes` maybe should instead be `reservedOffHeapMemoryBytes` or something similar. I'm open to naming suggestions
- this was largely written by Claude, with my steering, and I'm unfamiliar with Golang conventions, test frameworks, etc.