### PR TITLE
CVE-2026-25679: Bump go to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/go-java-launcher
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/mitchellh/go-ps v1.0.0


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
CVE-2026-25679 on go versions `1.26.0 <= version < 1.26.1`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
CVE-2026-25679: Bump go to 1.26.1
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

