### PR TITLE
Set MinRAMPercentage for percentage heap sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ variable):
 This will cause the JVM 11+ to discover the ``MaxRAM`` value using Linux cgroups, and calculate the heap sizes as the specified
 percentage of ``MaxRAM`` value, e.g. ``max-heap-size = MaxRAM * MaxRamPercentage``.
 
+When falling back to percentage-based heap sizing, the launcher sets ``MinRAMPercentage`` to the same value as
+``InitialRAMPercentage`` and ``MaxRAMPercentage`` so the configured percentage is also used for small memory limits.
+
 ### Overriding default values
 
 To override the heap percentage, developers can set `heapPercentage` in ``launcher-custom.yml``. This will use the cgroups memory limit to calculate the ``-Xmx|-Xms`` values, without the per processor adjustment. Setting ``-Xmx`` and ``-Xms`` to the same value ensures the heap will never shrink. 

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -328,13 +328,15 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 
 func filterHeapSizeArgs(args []string, heapPercentage *float64) []string {
 	var filtered []string
-	var hasMaxRAMPercentage, hasInitialRAMPercentage bool
+	var hasMinRAMPercentage, hasMaxRAMPercentage, hasInitialRAMPercentage bool
 	for _, arg := range args {
 		if !isHeapSizeArg(arg) {
 			filtered = append(filtered, arg)
 		}
 
-		if isMaxRAMPercentage(arg) {
+		if isMinRAMPercentage(arg) {
+			hasMinRAMPercentage = true
+		} else if isMaxRAMPercentage(arg) {
 			hasMaxRAMPercentage = true
 		} else if isInitialRAMPercentage(arg) {
 			hasInitialRAMPercentage = true
@@ -345,6 +347,9 @@ func filterHeapSizeArgs(args []string, heapPercentage *float64) []string {
 		percentage := 75.0
 		if heapPercentage != nil {
 			percentage = *heapPercentage
+		}
+		if !hasMinRAMPercentage {
+			filtered = append(filtered, fmt.Sprintf("-XX:MinRAMPercentage=%.1f", percentage))
 		}
 		filtered = append(filtered, fmt.Sprintf("-XX:InitialRAMPercentage=%.1f", percentage))
 		filtered = append(filtered, fmt.Sprintf("-XX:MaxRAMPercentage=%.1f", percentage))
@@ -407,6 +412,10 @@ func isHeapSizeArg(arg string) bool {
 
 func isAlwaysPreTouch(arg string) bool {
 	return arg == "-XX:+AlwaysPreTouch"
+}
+
+func isMinRAMPercentage(arg string) bool {
+	return strings.HasPrefix(arg, "-XX:MinRAMPercentage=")
 }
 
 func isMaxRAMPercentage(arg string) bool {

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -150,6 +150,56 @@ func TestMkdirChecksDirectorySyntax(t *testing.T) {
 	}
 }
 
+func TestFilterHeapSizeArgs(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		heapPercentage *float64
+		want           []string
+	}{
+		{
+			name: "sets default RAM percentages",
+			args: []string{"-Dfoo=bar", "-Xms1g", "-Xmx1g"},
+			want: []string{
+				"-Dfoo=bar",
+				"-XX:MinRAMPercentage=75.0",
+				"-XX:InitialRAMPercentage=75.0",
+				"-XX:MaxRAMPercentage=75.0",
+			},
+		},
+		{
+			name:           "sets configured RAM percentages",
+			args:           []string{"-Dfoo=bar"},
+			heapPercentage: new(10.0),
+			want: []string{
+				"-Dfoo=bar",
+				"-XX:MinRAMPercentage=10.0",
+				"-XX:InitialRAMPercentage=10.0",
+				"-XX:MaxRAMPercentage=10.0",
+			},
+		},
+		{
+			name: "preserves MinRAMPercentage override",
+			args: []string{"-XX:MinRAMPercentage=20.0"},
+			want: []string{
+				"-XX:MinRAMPercentage=20.0",
+				"-XX:InitialRAMPercentage=75.0",
+				"-XX:MaxRAMPercentage=75.0",
+			},
+		},
+		{
+			name: "preserves existing RAMPercentage overrides without setting defaults",
+			args: []string{"-XX:InitialRAMPercentage=50.0", "-XX:MaxRAMPercentage=80.0"},
+			want: []string{"-XX:InitialRAMPercentage=50.0", "-XX:MaxRAMPercentage=80.0"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, filterHeapSizeArgs(tc.args, tc.heapPercentage))
+		})
+	}
+}
+
 func TestFilterHeapSizeArgsV2(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Before this PR

The percentage-based heap sizing fallback sets InitialRAMPercentage and MaxRAMPercentage, but leaves MinRAMPercentage at the JVM default of 50%. HotSpot uses MinRAMPercentage for maximum heap sizing when available memory is small, so the configured percentage is not applied consistently.

Downstream users can work around this by adding another JVM option. However, installation-level jvmOpts configuration can replace product-level jvmOpts configuration as one block, clobbering unrelated product JVM options.

## After this PR

==COMMIT_MSG==
Set MinRAMPercentage alongside the generated InitialRAMPercentage and MaxRAMPercentage values. Preserve an explicitly configured MinRAMPercentage.
==COMMIT_MSG==

This centralizes the option in go-java-launcher and avoids requiring an installation override that can clobber product JVM options.

## Possible downsides?

For small-memory JVMs using the percentage fallback, the default maximum heap can increase from HotSpot's 50% default to go-java-launcher's intended 75%. Explicit RAM percentage overrides remain unchanged.