### PR TITLE
Add dedicated heap free ratio settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,18 +174,26 @@ when running inside a container, as per logic detailed above.
 ### Allowing the heap to shrink
 
 By default, the cgroup-based heap sizing sets ``-Xms`` equal to ``-Xmx`` so the heap is fixed and never shrinks. To
-instead let the JVM start with a small heap and grow or shrink it on demand, set the following in ``launcher-custom.yml``:
+instead let the JVM start with a small heap and grow or shrink it on demand, set ``allowHeapShrink`` in
+``launcher-custom.yml``. The optional heap free ratios tune when the heap expands or shrinks:
 
 ```yaml
 configType: java
 ...
 allowHeapShrink: true
+minHeapFreeRatio: 20
+maxHeapFreeRatio: 40
 ```
 
 When enabled, the launcher omits the generated ``-Xms`` flag (only ``-Xmx`` is set) and strips any
-``-XX:+AlwaysPreTouch`` from the JVM options, since pre-touching commits the full heap up front and defeats the purpose.
-This only takes effect in container mode (i.e. when the cgroup-based heap sizing path above is active); it has no effect
-when container support is disabled or a ``-XX:MaxRAM=`` override is present.
+``-XX:+AlwaysPreTouch`` from the JVM options. Each ratio is an integer in ``[0, 100]`` and independently replaces only
+the matching ``jvmOpts`` entries, allowing installation-level ratio overrides without replacing product-level
+``jvmOpts``. The JVM defaults are 40 for minimum and 70 for maximum. When both dedicated settings are present, the
+launcher requires ``minHeapFreeRatio <= maxHeapFreeRatio``; the JVM validates pairs that mix a dedicated setting with
+``jvmOpts``.
+
+These settings only take effect in the cgroup-based heap sizing path. They have no effect when container support is
+disabled or a ``-XX:MaxRAM=`` override is present.
 
 ### Disabling container support
 

--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -76,6 +76,15 @@ type CustomLauncherConfig struct {
 	// The equivalent field under experimental is retained for backwards compatibility with existing overrides;
 	// either setting being true enables the behavior.
 	AllowHeapShrink bool `yaml:"allowHeapShrink,omitempty"`
+	// MinHeapFreeRatio and MaxHeapFreeRatio, when set, add -XX:MinHeapFreeRatio and -XX:MaxHeapFreeRatio to the JVM
+	// options in the cgroup-based heap sizing path, replacing any equivalents already present in jvmOpts. Both are
+	// integer percentages in [0, 100] and the JVM requires MinHeapFreeRatio <= MaxHeapFreeRatio. They only influence
+	// the JVM once the heap is allowed to resize (e.g. with allowHeapShrink: true); with a fixed heap (-Xms == -Xmx)
+	// they have no effect. Only takes effect in container mode (CONTAINER env var set and dangerousDisableContainerSupport
+	// is false). Exposed as dedicated options so installation-level heap ratio overrides do not replace the product-level
+	// jvmOpts list.
+	MinHeapFreeRatio *int `yaml:"minHeapFreeRatio,omitempty"`
+	MaxHeapFreeRatio *int `yaml:"maxHeapFreeRatio,omitempty"`
 }
 
 type ExperimentalLauncherConfig struct {
@@ -289,11 +298,38 @@ func parseCustomConfig(yamlString []byte) (PrimaryCustomLauncherConfig, error) {
 			return PrimaryCustomLauncherConfig{}, errors.Wrapf(err, "invalid launch config in custom "+
 				"subProcess config %s", name)
 		}
+
+		if err := validateHeapFreeRatio(subProcess); err != nil {
+			return PrimaryCustomLauncherConfig{}, errors.Wrapf(err, "invalid heap free ratio config in custom "+
+				"subProcess config %s", name)
+		}
 	}
 	if err := validateExecutionMode(config.Experimental.ExecutionMode); err != nil {
 		return PrimaryCustomLauncherConfig{}, err
 	}
+	if err := validateHeapFreeRatio(config.CustomLauncherConfig); err != nil {
+		return PrimaryCustomLauncherConfig{}, err
+	}
 	return config, nil
+}
+
+// validateHeapFreeRatio validates the bounds of each dedicated heap free ratio setting and compares them when both
+// are set. It does not inspect jvmOpts, so the JVM validates pairs that combine a dedicated setting with a jvmOpts
+// entry for the other ratio. These checks are performed directly because CustomLauncherConfig is not passed to
+// validator.Validate.
+func validateHeapFreeRatio(config CustomLauncherConfig) error {
+	if config.MinHeapFreeRatio != nil && (*config.MinHeapFreeRatio < 0 || *config.MinHeapFreeRatio > 100) {
+		return errors.Errorf("minHeapFreeRatio must be in [0, 100], found %d", *config.MinHeapFreeRatio)
+	}
+	if config.MaxHeapFreeRatio != nil && (*config.MaxHeapFreeRatio < 0 || *config.MaxHeapFreeRatio > 100) {
+		return errors.Errorf("maxHeapFreeRatio must be in [0, 100], found %d", *config.MaxHeapFreeRatio)
+	}
+	if config.MinHeapFreeRatio != nil && config.MaxHeapFreeRatio != nil &&
+		*config.MinHeapFreeRatio > *config.MaxHeapFreeRatio {
+		return errors.Errorf("minHeapFreeRatio (%d) must be less than or equal to maxHeapFreeRatio (%d)",
+			*config.MinHeapFreeRatio, *config.MaxHeapFreeRatio)
+	}
+	return nil
 }
 
 func getCustomConfigFromFile(customConfigFile string, stdout io.Writer) (PrimaryCustomLauncherConfig, error) {

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -410,6 +410,27 @@ allowHeapShrink: true
 			},
 		},
 		{
+			name: "min and max heap free ratio are parsed",
+			data: `
+configType: java
+configVersion: 1
+minHeapFreeRatio: 20
+maxHeapFreeRatio: 40
+`,
+			want: PrimaryCustomLauncherConfig{
+				VersionedConfig: VersionedConfig{
+					Version: 1,
+				},
+				CustomLauncherConfig: CustomLauncherConfig{
+					TypedConfig: TypedConfig{
+						Type: "java",
+					},
+					MinHeapFreeRatio: new(20),
+					MaxHeapFreeRatio: new(40),
+				},
+			},
+		},
+		{
 			name: "executionMode is parsed",
 			data: `
 configType: java
@@ -613,4 +634,44 @@ subProcesses:
 		assert.Regexp(t, currCase.msg, err.Error(), "Case %d: %s had the wrong error message", i, currCase.name)
 	}
 
+}
+
+func TestValidateHeapFreeRatio(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data string
+		msg  string
+	}{
+		{
+			name: "minHeapFreeRatio below range",
+			data: "configType: java\nconfigVersion: 1\nminHeapFreeRatio: -1\n",
+			msg:  "minHeapFreeRatio must be in \\[0, 100\\], found -1",
+		},
+		{
+			name: "maxHeapFreeRatio above range",
+			data: "configType: java\nconfigVersion: 1\nmaxHeapFreeRatio: 101\n",
+			msg:  "maxHeapFreeRatio must be in \\[0, 100\\], found 101",
+		},
+		{
+			name: "min greater than max",
+			data: "configType: java\nconfigVersion: 1\nminHeapFreeRatio: 80\nmaxHeapFreeRatio: 40\n",
+			msg:  "minHeapFreeRatio \\(80\\) must be less than or equal to maxHeapFreeRatio \\(40\\)",
+		},
+		{
+			name: "invalid ratio in subProcess",
+			data: "configType: java\nconfigVersion: 1\nsubProcesses:\n  sidecar:\n    configType: java\n    maxHeapFreeRatio: 200\n",
+			msg:  "invalid heap free ratio config in custom subProcess config sidecar: maxHeapFreeRatio must be in \\[0, 100\\], found 200",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseCustomConfig([]byte(tc.data))
+			assert.Error(t, err, "%s expected an error", tc.name)
+			assert.Regexp(t, tc.msg, err.Error(), "%s had the wrong error message", tc.name)
+		})
+	}
+}
+
+func TestValidateHeapFreeRatioAllowsOneValue(t *testing.T) {
+	assert.NoError(t, validateHeapFreeRatio(CustomLauncherConfig{MinHeapFreeRatio: new(80)}))
+	assert.NoError(t, validateHeapFreeRatio(CustomLauncherConfig{MaxHeapFreeRatio: new(20)}))
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -312,7 +312,11 @@ func createJvmOpts(combinedJvmOpts []string, customConfig *CustomLauncherConfig,
 			_, _ = fmt.Fprintf(logger, "Cgroup memory limit unusually high (%d bytes), falling back to percentage-based heap sizing\n", cgroupMemoryLimitInBytes)
 			return filterHeapSizeArgs(combinedJvmOpts, customConfig.HeapPercentage)
 		}
-		return filterHeapSizeArgsV2(combinedJvmOpts, customConfig.HeapPercentage, cgroupMemoryLimitInBytes, customConfig.AllowHeapShrink || customConfig.Experimental.AllowHeapShrink)
+		return filterHeapSizeArgsV2(combinedJvmOpts, customConfig.HeapPercentage, cgroupMemoryLimitInBytes, heapSizeOptions{
+			allowHeapShrink:  customConfig.AllowHeapShrink || customConfig.Experimental.AllowHeapShrink,
+			minHeapFreeRatio: customConfig.MinHeapFreeRatio,
+			maxHeapFreeRatio: customConfig.MaxHeapFreeRatio,
+		})
 	}
 
 	if isEnvVarSet("CONTAINER") {
@@ -364,14 +368,29 @@ func getCGroupMemoryLimitInBytes() (uint64, error) {
 	return cgroupMemoryLimitInBytes, nil
 }
 
-func filterHeapSizeArgsV2(args []string, heapPercentage *float64, cgroupMemoryLimitInBytes uint64, allowHeapShrink bool) []string {
+// heapSizeOptions carries the launcher-managed heap tuning flags derived from the custom launcher config. Dedicated
+// fields allow installation-level heap ratio overrides without replacing the product-level jvmOpts list.
+type heapSizeOptions struct {
+	allowHeapShrink  bool
+	minHeapFreeRatio *int
+	maxHeapFreeRatio *int
+}
+
+func filterHeapSizeArgsV2(args []string, heapPercentage *float64, cgroupMemoryLimitInBytes uint64, opts heapSizeOptions) []string {
 	var filtered []string
 	var hasMaxRAMPercentage, hasInitialRAMPercentage bool
 	for _, arg := range args {
 		if isHeapSizeArg(arg) {
 			continue
 		}
-		if allowHeapShrink && isAlwaysPreTouch(arg) {
+		if opts.allowHeapShrink && isAlwaysPreTouch(arg) {
+			continue
+		}
+		// When a ratio is configured, drop any equivalent from jvmOpts so the config value wins.
+		if opts.minHeapFreeRatio != nil && isMinHeapFreeRatio(arg) {
+			continue
+		}
+		if opts.maxHeapFreeRatio != nil && isMaxHeapFreeRatio(arg) {
 			continue
 		}
 		filtered = append(filtered, arg)
@@ -385,10 +404,19 @@ func filterHeapSizeArgsV2(args []string, heapPercentage *float64, cgroupMemoryLi
 
 	if !hasInitialRAMPercentage && !hasMaxRAMPercentage {
 		jvmHeapSizeInBytes := ComputeJVMHeapSizeInBytes(runtime.NumCPU(), cgroupMemoryLimitInBytes, heapPercentage)
-		if !allowHeapShrink {
+		if !opts.allowHeapShrink {
 			filtered = append(filtered, fmt.Sprintf("-Xms%d", jvmHeapSizeInBytes))
 		}
 		filtered = append(filtered, fmt.Sprintf("-Xmx%d", jvmHeapSizeInBytes))
+	}
+
+	// Heap free ratios are orthogonal to the heap sizing method, so append them regardless of whether the RAM
+	// percentage overrides above are present.
+	if opts.minHeapFreeRatio != nil {
+		filtered = append(filtered, fmt.Sprintf("-XX:MinHeapFreeRatio=%d", *opts.minHeapFreeRatio))
+	}
+	if opts.maxHeapFreeRatio != nil {
+		filtered = append(filtered, fmt.Sprintf("-XX:MaxHeapFreeRatio=%d", *opts.maxHeapFreeRatio))
 	}
 	return filtered
 }
@@ -407,6 +435,14 @@ func isHeapSizeArg(arg string) bool {
 
 func isAlwaysPreTouch(arg string) bool {
 	return arg == "-XX:+AlwaysPreTouch"
+}
+
+func isMinHeapFreeRatio(arg string) bool {
+	return strings.HasPrefix(arg, "-XX:MinHeapFreeRatio=")
+}
+
+func isMaxHeapFreeRatio(arg string) bool {
+	return strings.HasPrefix(arg, "-XX:MaxHeapFreeRatio=")
 }
 
 func isMaxRAMPercentage(arg string) bool {

--- a/launchlib/launcher_test.go
+++ b/launchlib/launcher_test.go
@@ -152,13 +152,15 @@ func TestMkdirChecksDirectorySyntax(t *testing.T) {
 
 func TestFilterHeapSizeArgsV2(t *testing.T) {
 	tests := []struct {
-		name            string
-		args            []string
-		cgroupMemory    uint64
-		heapPercentage  *float64
-		allowHeapShrink bool
-		wantContains    []string
-		wantNotContains []string
+		name             string
+		args             []string
+		cgroupMemory     uint64
+		heapPercentage   *float64
+		allowHeapShrink  bool
+		minHeapFreeRatio *int
+		maxHeapFreeRatio *int
+		wantContains     []string
+		wantNotContains  []string
 	}{
 		{
 			name:            "allowHeapShrink false sets both Xms and Xmx",
@@ -216,10 +218,95 @@ func TestFilterHeapSizeArgsV2(t *testing.T) {
 				fmt.Sprintf("-Xmx%d", 1*BytesInMebibyte),
 			},
 		},
+		{
+			name:             "min and max heap free ratio are appended when set",
+			args:             []string{"-Dfoo=bar"},
+			cgroupMemory:     10 * BytesInMebibyte,
+			heapPercentage:   new(10.0),
+			allowHeapShrink:  true,
+			minHeapFreeRatio: new(20),
+			maxHeapFreeRatio: new(40),
+			wantContains: []string{
+				"-Dfoo=bar",
+				"-XX:MinHeapFreeRatio=20",
+				"-XX:MaxHeapFreeRatio=40",
+			},
+		},
+		{
+			name:             "configured ratio overrides value present in jvmOpts",
+			args:             []string{"-Dfoo=bar", "-XX:MaxHeapFreeRatio=90", "-XX:MinHeapFreeRatio=5"},
+			cgroupMemory:     10 * BytesInMebibyte,
+			heapPercentage:   new(10.0),
+			minHeapFreeRatio: new(20),
+			maxHeapFreeRatio: new(40),
+			wantContains: []string{
+				"-XX:MinHeapFreeRatio=20",
+				"-XX:MaxHeapFreeRatio=40",
+			},
+			wantNotContains: []string{
+				"-XX:MaxHeapFreeRatio=90",
+				"-XX:MinHeapFreeRatio=5",
+			},
+		},
+		{
+			name:             "configured min ratio preserves max ratio in jvmOpts",
+			args:             []string{"-XX:MinHeapFreeRatio=5", "-XX:MaxHeapFreeRatio=90"},
+			cgroupMemory:     10 * BytesInMebibyte,
+			heapPercentage:   new(10.0),
+			minHeapFreeRatio: new(20),
+			wantContains: []string{
+				"-XX:MinHeapFreeRatio=20",
+				"-XX:MaxHeapFreeRatio=90",
+			},
+			wantNotContains: []string{"-XX:MinHeapFreeRatio=5"},
+		},
+		{
+			name:             "configured max ratio preserves min ratio in jvmOpts",
+			args:             []string{"-XX:MinHeapFreeRatio=5", "-XX:MaxHeapFreeRatio=90"},
+			cgroupMemory:     10 * BytesInMebibyte,
+			heapPercentage:   new(10.0),
+			maxHeapFreeRatio: new(40),
+			wantContains: []string{
+				"-XX:MinHeapFreeRatio=5",
+				"-XX:MaxHeapFreeRatio=40",
+			},
+			wantNotContains: []string{"-XX:MaxHeapFreeRatio=90"},
+		},
+		{
+			name:           "ratio present in jvmOpts is preserved when option is unset",
+			args:           []string{"-Dfoo=bar", "-XX:MaxHeapFreeRatio=90"},
+			cgroupMemory:   10 * BytesInMebibyte,
+			heapPercentage: new(10.0),
+			wantContains: []string{
+				"-XX:MaxHeapFreeRatio=90",
+			},
+		},
+		{
+			name:             "heap free ratio appended alongside RAMPercentage overrides",
+			args:             []string{"-XX:InitialRAMPercentage=50.0", "-XX:MaxRAMPercentage=80.0"},
+			cgroupMemory:     10 * BytesInMebibyte,
+			heapPercentage:   new(10.0),
+			minHeapFreeRatio: new(30),
+			maxHeapFreeRatio: new(60),
+			wantContains: []string{
+				"-XX:InitialRAMPercentage=50.0",
+				"-XX:MaxRAMPercentage=80.0",
+				"-XX:MinHeapFreeRatio=30",
+				"-XX:MaxHeapFreeRatio=60",
+			},
+			wantNotContains: []string{
+				fmt.Sprintf("-Xms%d", 1*BytesInMebibyte),
+				fmt.Sprintf("-Xmx%d", 1*BytesInMebibyte),
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := filterHeapSizeArgsV2(tc.args, tc.heapPercentage, tc.cgroupMemory, tc.allowHeapShrink)
+			result := filterHeapSizeArgsV2(tc.args, tc.heapPercentage, tc.cgroupMemory, heapSizeOptions{
+				allowHeapShrink:  tc.allowHeapShrink,
+				minHeapFreeRatio: tc.minHeapFreeRatio,
+				maxHeapFreeRatio: tc.maxHeapFreeRatio,
+			})
 			for _, want := range tc.wantContains {
 				assert.Contains(t, result, want)
 			}


### PR DESCRIPTION
## Before this PR

Products can configure `-XX:MinHeapFreeRatio` and `-XX:MaxHeapFreeRatio` through `jvmOpts`. However, installation-level `jvmOpts` configuration replaces the product-level list as a block, so an installation override can unintentionally remove unrelated product JVM options.

## After this PR

==COMMIT_MSG==
Add dedicated `minHeapFreeRatio` and `maxHeapFreeRatio` launcher settings.
==COMMIT_MSG==

In the cgroup-based heap sizing path, each dedicated setting is applied independently:

- A configured `minHeapFreeRatio` replaces all `-XX:MinHeapFreeRatio` entries in `jvmOpts` without affecting `-XX:MaxHeapFreeRatio` entries.
- A configured `maxHeapFreeRatio` replaces all `-XX:MaxHeapFreeRatio` entries in `jvmOpts` without affecting `-XX:MinHeapFreeRatio` entries.
- An unset setting leaves matching entries in `jvmOpts` untouched. The JVM default applies when neither source provides a value.

The launcher validates each dedicated value's range and compares the pair when both dedicated settings are present. When a dedicated setting is combined with a `jvmOpts` entry for the other ratio, the JVM validates the effective pair at process startup.

This allows product heap tuning to survive installation-level `jvmOpts` replacement without changing an independently configured ratio.

## Possible downsides?

An invalid ratio pair assembled from a dedicated setting and a `jvmOpts` entry is detected by the JVM at process startup rather than during launcher config parsing. The dedicated settings only take effect in the cgroup-based heap sizing path.
