### PR TITLE
Add windows support for go-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,5 +243,9 @@ primary process.
 Note that while the specification states that the `status` command prints the status of the service, the exact wording
 used to denote that status is not defined and subsequently subject to change without warning.
 
+## Windows support
+
+When running on windows go-init will not attempt to gracefully shutdown the process, due to signal limiations on detached processes.
+
 # License
 This repository is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ used to denote that status is not defined and subsequently subject to change wit
 
 ## Windows support
 
-When running on windows go-init will not attempt to gracefully shutdown the process, due to signal limiations on detached processes.
+When running on windows go-init will not attempt to gracefully shutdown the process, due to signal limitations on detached processes.
 
 # License
 This repository is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/palantir/pkg/cli v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sys v0.47.0
 	gopkg.in/validator.v2 v2.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -20,7 +21,6 @@ require (
 	github.com/palantir/pkg v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -9,6 +9,8 @@ products:
         arch: amd64
       - os: linux
         arch: arm64
+      - os: windows
+        arch: amd64
     dist:
       disters:
         bin:

--- a/init/cli/lib-unix.go
+++ b/init/cli/lib-unix.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build unix
+// +build unix
 
 package cli
 
@@ -9,6 +9,19 @@ import (
 
 	ps "github.com/mitchellh/go-ps"
 )
+
+func isPidRunning(pid int) (bool, *os.Process, error) {
+	// in unix systems os.FindProcess never fails
+	proc, _ := os.FindProcess(pid)
+	running, err := isProcRunning(proc)
+	if err != nil {
+		return false, nil, err
+	}
+	if running {
+		return true, proc, nil
+	}
+	return false, nil, nil
+}
 
 func isProcRunning(proc *os.Process) (bool, error) {
 	// This is the way to check if a process exists: https://linux.die.net/man/2/kill.

--- a/init/cli/lib-unix.go
+++ b/init/cli/lib-unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+// +build !windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+
+	ps "github.com/mitchellh/go-ps"
+)
+
+func isProcRunning(proc *os.Process) (bool, error) {
+	// This is the way to check if a process exists: https://linux.die.net/man/2/kill.
+	// On linux, this may respond true if there is a thread running with the same id.
+	running := proc.Signal(syscall.Signal(0)) == nil
+	if !running {
+		return false, nil
+	}
+
+	// On linux, iterating over processes will only return running processes. Unfortunately,
+	// getting exactly the one pid will also return a thread of the same id.
+	procs, err := ps.Processes()
+	if err != nil {
+		return false, err
+	}
+	for _, p := range procs {
+		if p.Pid() == proc.Pid {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/init/cli/lib-windows.go
+++ b/init/cli/lib-windows.go
@@ -4,7 +4,6 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 
@@ -16,7 +15,6 @@ func isPidRunning(pid int) (bool, *os.Process, error) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		// If the process is not found, treat it as not running
-		fmt.Errorf("isPidRunning: %s", err)
 		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
 			return false, nil, nil
 		}
@@ -36,7 +34,6 @@ func isProcRunning(proc *os.Process) (bool, error) {
 	handle, err := syscall.OpenProcess(syscall.PROCESS_QUERY_INFORMATION, false, uint32(proc.Pid))
 	if err != nil {
 		// If the process is not found, treat it as not running
-		fmt.Errorf("isProcRunning: %s", err)
 		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
 			return false, nil
 		}

--- a/init/cli/lib-windows.go
+++ b/init/cli/lib-windows.go
@@ -12,9 +12,32 @@ const (
 	stillActive = 259
 )
 
+func isPidRunning(pid int) (bool, *os.Process, error) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, nil, nil
+	}
+	running, err := isProcRunning(proc)
+	if err != nil {
+		// If the process is not found, treat it as not running
+		if err == syscall.ERROR_PROC_NOT_FOUND {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	if running {
+		return true, proc, nil
+	}
+	return false, nil, nil
+}
+
 func isProcRunning(proc *os.Process) (bool, error) {
 	handle, err := syscall.OpenProcess(syscall.PROCESS_QUERY_INFORMATION, false, uint32(proc.Pid))
 	if err != nil {
+		// If the process is not found, treat it as not running
+		if err == syscall.ERROR_PROC_NOT_FOUND {
+			return false, nil
+		}
 		return false, err
 	}
 	defer syscall.CloseHandle(handle)

--- a/init/cli/lib-windows.go
+++ b/init/cli/lib-windows.go
@@ -4,8 +4,12 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -15,14 +19,15 @@ const (
 func isPidRunning(pid int) (bool, *os.Process, error) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
-		return false, nil, nil
+		// If the process is not found, treat it as not running
+		fmt.Errorf("isPidRunning: %s", err)
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return false, nil, nil
+		}
+		return false, nil, err
 	}
 	running, err := isProcRunning(proc)
 	if err != nil {
-		// If the process is not found, treat it as not running
-		if err == syscall.ERROR_PROC_NOT_FOUND {
-			return false, nil, nil
-		}
 		return false, nil, err
 	}
 	if running {
@@ -35,7 +40,8 @@ func isProcRunning(proc *os.Process) (bool, error) {
 	handle, err := syscall.OpenProcess(syscall.PROCESS_QUERY_INFORMATION, false, uint32(proc.Pid))
 	if err != nil {
 		// If the process is not found, treat it as not running
-		if err == syscall.ERROR_PROC_NOT_FOUND {
+		fmt.Errorf("isProcRunning: %s", err)
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
 			return false, nil
 		}
 		return false, err

--- a/init/cli/lib-windows.go
+++ b/init/cli/lib-windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+// +build windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	stillActive = 259
+)
+
+func isProcRunning(proc *os.Process) (bool, error) {
+	handle, err := syscall.OpenProcess(syscall.PROCESS_QUERY_INFORMATION, false, uint32(proc.Pid))
+	if err != nil {
+		return false, err
+	}
+	defer syscall.CloseHandle(handle)
+
+	var exitCode uint32
+	if err := syscall.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false, err
+	}
+
+	return exitCode == stillActive, nil
+}

--- a/init/cli/lib-windows.go
+++ b/init/cli/lib-windows.go
@@ -12,10 +12,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const (
-	stillActive = 259
-)
-
 func isPidRunning(pid int) (bool, *os.Process, error) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
@@ -52,6 +48,7 @@ func isProcRunning(proc *os.Process) (bool, error) {
 	if err := syscall.GetExitCodeProcess(handle, &exitCode); err != nil {
 		return false, err
 	}
-
-	return exitCode == stillActive, nil
+	// If the exit code equals status pending the process has not exited
+	// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess#remarks
+	return windows.NTStatus(exitCode) == windows.STATUS_PENDING, nil
 }

--- a/init/cli/lib.go
+++ b/init/cli/lib.go
@@ -146,18 +146,3 @@ func getConfiguredCommands(ctx cli.Context, loggers launchlib.ServiceLoggers) (m
 	}
 	return cmds, nil
 }
-
-func isPidRunning(pid int) (bool, *os.Process, error) {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false, nil, nil
-	}
-	running, err := isProcRunning(proc)
-	if err != nil {
-		return false, nil, err
-	}
-	if running {
-		return true, proc, nil
-	}
-	return false, nil, nil
-}

--- a/init/cli/lib.go
+++ b/init/cli/lib.go
@@ -21,9 +21,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
-	ps "github.com/mitchellh/go-ps"
 	"github.com/palantir/go-java-launcher/launchlib"
 	"github.com/palantir/pkg/cli"
 	"github.com/pkg/errors"
@@ -150,8 +148,10 @@ func getConfiguredCommands(ctx cli.Context, loggers launchlib.ServiceLoggers) (m
 }
 
 func isPidRunning(pid int) (bool, *os.Process, error) {
-	// Docs say FindProcess always succeeds on Unix.
-	proc, _ := os.FindProcess(pid)
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, nil, err
+	}
 	running, err := isProcRunning(proc)
 	if err != nil {
 		return false, nil, err
@@ -160,26 +160,4 @@ func isPidRunning(pid int) (bool, *os.Process, error) {
 		return true, proc, nil
 	}
 	return false, nil, nil
-}
-
-func isProcRunning(proc *os.Process) (bool, error) {
-	// This is the way to check if a process exists: https://linux.die.net/man/2/kill.
-	// On linux, this may respond true if there is a thread running with the same id.
-	running := proc.Signal(syscall.Signal(0)) == nil
-	if !running {
-		return false, nil
-	}
-
-	// On linux, iterating over processes will only return running processes. Unfortunately,
-	// getting exactly the one pid will also return a thread of the same id.
-	procs, err := ps.Processes()
-	if err != nil {
-		return false, err
-	}
-	for _, p := range procs {
-		if p.Pid() == proc.Pid {
-			return true, nil
-		}
-	}
-	return false, nil
 }

--- a/init/cli/lib.go
+++ b/init/cli/lib.go
@@ -150,7 +150,7 @@ func getConfiguredCommands(ctx cli.Context, loggers launchlib.ServiceLoggers) (m
 func isPidRunning(pid int) (bool, *os.Process, error) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
-		return false, nil, err
+		return false, nil, nil
 	}
 	running, err := isProcRunning(proc)
 	if err != nil {

--- a/init/cli/stop-unix.go
+++ b/init/cli/stop-unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+// +build unix
+
+package cli
+
+import (
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/palantir/pkg/cli"
+	"github.com/pkg/errors"
+)
+
+func stopService(ctx cli.Context, procs map[string]*os.Process) error {
+	for name, proc := range procs {
+		if err := proc.Signal(syscall.SIGTERM); err != nil && !strings.Contains(err.Error(),
+			"os: process already finished") {
+			return errors.Wrapf(err, "failed to stop '%s' process", name)
+		}
+	}
+
+	if err := waitForServiceToStop(ctx, procs); err != nil {
+		return errors.Wrap(err, "failed to stop at least one process")
+	}
+
+	return nil
+}

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -14,7 +14,7 @@ import (
 
 func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 	for name, proc := range procs {
-		handle, err := syscall.OpenProcess(syscall.PROCESS_TERMINATE, false, uint32(proc.Pid))
+		handle, err := syscall.OpenProcess(syscall.PROCESS_TERMINATE|syscall.PROCESS_QUERY_INFORMATION, false, uint32(proc.Pid))
 		if err != nil {
 			// If the process is not found, it's already stopped
 			if err == windows.ERROR_INVALID_PARAMETER {
@@ -31,7 +31,7 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 				var exitCode uint32
 				// If the exit code equals status pending the process has not exited
 				// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess#remarks
-				if errCode := syscall.GetExitCodeProcess(handle, &exitCode); errCode != nil || windows.NTStatus(exitCode) != windows.STATUS_PENDING {
+				if errCode := syscall.GetExitCodeProcess(handle, &exitCode); errCode != nil || windows.NTStatus(exitCode) == windows.STATUS_PENDING {
 					// We could not terminate the process due to access denied
 					return errors.Wrapf(err, "failed to terminate '%s' process", name)
 				}

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -26,6 +26,11 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 		err = syscall.TerminateProcess(handle, 1)
 		syscall.CloseHandle(handle)
 		if err != nil {
+			// If the process already exited, that's fine - continue to next process
+			if err == windows.ERROR_ACCESS_DENIED {
+				// Process may have already exited, continue
+				continue
+			}
 			return errors.Wrapf(err, "failed to terminate '%s' process", name)
 		}
 	}

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -31,12 +31,12 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 				var exitCode uint32
 				// If the exit code equals status pending the process has not exited
 				// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess#remarks
-				if errCode := syscall.GetExitCodeProcess(handle, &exitCode); errCode != nil || windows.NTStatus(exitCode) == windows.STATUS_PENDING {
+				if errCode := syscall.GetExitCodeProcess(handle, &exitCode); errCode != nil || windows.NTStatus(exitCode) != windows.STATUS_PENDING {
 					// We could not terminate the process due to access denied
 					return errors.Wrapf(err, "failed to terminate '%s' process", name)
 				}
 
-				// We got denied from exiting a process that already finsished
+				// We got denied from terminating a process that already finsished
 				continue
 			}
 			return errors.Wrapf(err, "failed to terminate '%s' process", name)

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -23,12 +23,20 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 			return errors.Wrapf(err, "failed to open '%s' process for termination", name)
 		}
 
-		err = syscall.TerminateProcess(handle, 1)
-		syscall.CloseHandle(handle)
-		if err != nil {
-			// If the process already exited, that's fine - continue to next process
+		defer syscall.CloseHandle(handle)
+		if syscall.TerminateProcess(handle, 1) != nil {
+			// Windows might return an access denied when attempting to terminate a process that
+			// has already finished.
 			if err == windows.ERROR_ACCESS_DENIED {
-				// Process may have already exited, continue
+				var exitCode uint32
+				// If the exit code equals status pending the process has not exited
+				// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess#remarks
+				if errCode := syscall.GetExitCodeProcess(handle, &exitCode); errCode != nil || windows.NTStatus(exitCode) == windows.STATUS_PENDING {
+					// We could not terminate the process due to access denied
+					return errors.Wrapf(err, "failed to terminate '%s' process", name)
+				}
+
+				// We got denied from exiting a process that already finsished
 				continue
 			}
 			return errors.Wrapf(err, "failed to terminate '%s' process", name)

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -27,7 +27,7 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 		if err := syscall.TerminateProcess(handle, 1); err != nil {
 			// Windows might return an access denied when attempting to terminate a process that
 			// has already finished.
-			if err == windows.ERROR_ACCESS_DENIED {
+			if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
 				var exitCode uint32
 				// If the exit code equals status pending the process has not exited
 				// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess#remarks

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+// +build windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/palantir/pkg/cli"
+	"github.com/pkg/errors"
+)
+
+func stopService(ctx cli.Context, procs map[string]*os.Process) error {
+	for name, proc := range procs {
+		handle, err := syscall.OpenProcess(syscall.PROCESS_TERMINATE, false, uint32(proc.Pid))
+		if err != nil {
+			// If the process is not found, it's already stopped
+			if err == syscall.ERROR_PROC_NOT_FOUND {
+				continue
+			}
+			return errors.Wrapf(err, "failed to open '%s' process for termination", name)
+		}
+		defer syscall.CloseHandle(handle)
+
+		if err := syscall.TerminateProcess(handle, 1); err != nil {
+			return errors.Wrapf(err, "failed to terminate '%s' process", name)
+		}
+	}
+
+	if err := waitForServiceToStop(ctx, procs); err != nil {
+		return errors.Wrap(err, "failed to stop at least one process")
+	}
+
+	return nil
+}

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -22,9 +22,10 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 			}
 			return errors.Wrapf(err, "failed to open '%s' process for termination", name)
 		}
-		defer syscall.CloseHandle(handle)
 
-		if err := syscall.TerminateProcess(handle, 1); err != nil {
+		err = syscall.TerminateProcess(handle, 1)
+		syscall.CloseHandle(handle)
+		if err != nil {
 			return errors.Wrapf(err, "failed to terminate '%s' process", name)
 		}
 	}

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/palantir/pkg/cli"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
 func stopService(ctx cli.Context, procs map[string]*os.Process) error {
@@ -16,7 +17,7 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 		handle, err := syscall.OpenProcess(syscall.PROCESS_TERMINATE, false, uint32(proc.Pid))
 		if err != nil {
 			// If the process is not found, it's already stopped
-			if err == syscall.ERROR_PROC_NOT_FOUND {
+			if err == windows.ERROR_INVALID_PARAMETER {
 				continue
 			}
 			return errors.Wrapf(err, "failed to open '%s' process for termination", name)

--- a/init/cli/stop-windows.go
+++ b/init/cli/stop-windows.go
@@ -24,7 +24,7 @@ func stopService(ctx cli.Context, procs map[string]*os.Process) error {
 		}
 
 		defer syscall.CloseHandle(handle)
-		if syscall.TerminateProcess(handle, 1) != nil {
+		if err := syscall.TerminateProcess(handle, 1); err != nil {
 			// Windows might return an access denied when attempting to terminate a process that
 			// has already finished.
 			if err == windows.ERROR_ACCESS_DENIED {

--- a/init/cli/stop.go
+++ b/init/cli/stop.go
@@ -17,8 +17,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"strings"
-	"syscall"
 	"time"
 
 	time2 "github.com/palantir/go-java-launcher/init/cli/time"
@@ -78,20 +76,6 @@ func stop(ctx cli.Context, loggers launchlib.ServiceLoggers) error {
 	return nil
 }
 
-func stopService(ctx cli.Context, procs map[string]*os.Process) error {
-	for name, proc := range procs {
-		if err := proc.Signal(syscall.SIGTERM); err != nil && !strings.Contains(err.Error(),
-			"os: process already finished") {
-			return errors.Wrapf(err, "failed to stop '%s' process", name)
-		}
-	}
-
-	if err := waitForServiceToStop(ctx, procs); err != nil {
-		return errors.Wrap(err, "failed to stop at least one process")
-	}
-
-	return nil
-}
 
 func waitForServiceToStop(ctx cli.Context, procs map[string]*os.Process) error {
 	const numSecondsToWait = 240

--- a/init/cli/stop.go
+++ b/init/cli/stop.go
@@ -76,7 +76,6 @@ func stop(ctx cli.Context, loggers launchlib.ServiceLoggers) error {
 	return nil
 }
 
-
 func waitForServiceToStop(ctx cli.Context, procs map[string]*os.Process) error {
 	const numSecondsToWait = 240
 	timer := Clock.NewTimer(numSecondsToWait * time.Second)

--- a/launchlib/launcher-unix.go
+++ b/launchlib/launcher-unix.go
@@ -3,4 +3,4 @@
 
 package launchlib
 
-const javaExecutablePath = "bin/java.exe"
+const javaExecutablePath = "bin/java"

--- a/launchlib/launcher-unix.go
+++ b/launchlib/launcher-unix.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build unix
+// +build unix
 
 package launchlib
 

--- a/launchlib/launcher-unix.go
+++ b/launchlib/launcher-unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+// +build !windows
+
+package launchlib
+
+import (
+	"os/exec"
+)
+
+const javaExecutablePath = "bin/java.exe"
+
+func setSysProcAttr(cmd *exec.Cmd) {}

--- a/launchlib/launcher-unix.go
+++ b/launchlib/launcher-unix.go
@@ -3,4 +3,8 @@
 
 package launchlib
 
-const javaExecutablePath = "bin/java"
+const (
+	javaExecutablePath = "bin/java"
+	// pathBlackListRegex matches characters disallowed in Unix paths we allow for program arguments
+	pathBlackListRegex = `[^\w.\/_\-]`
+)

--- a/launchlib/launcher-unix.go
+++ b/launchlib/launcher-unix.go
@@ -3,10 +3,4 @@
 
 package launchlib
 
-import (
-	"os/exec"
-)
-
 const javaExecutablePath = "bin/java.exe"
-
-func setSysProcAttr(cmd *exec.Cmd) {}

--- a/launchlib/launcher-windows.go
+++ b/launchlib/launcher-windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+// +build windows
+
+package launchlib
+
+import (
+	"os/exec"
+
+	"golang.org/x/sys/windows"
+)
+
+const javaExecutablePath = "bin/java.exe"
+
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &windows.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+	}
+}

--- a/launchlib/launcher-windows.go
+++ b/launchlib/launcher-windows.go
@@ -3,4 +3,9 @@
 
 package launchlib
 
-const javaExecutablePath = "bin/java.exe"
+const (
+	javaExecutablePath = "bin/java.exe"
+	// pathBlackListRegex matches characters disallowed in Windows paths we allow for program arguments
+	// Windows paths need : for drive letters, \ for path separators, and spaces for paths like "Program Files"
+	pathBlackListRegex = `[^\w.\/\\_\-: ]`
+)

--- a/launchlib/launcher-windows.go
+++ b/launchlib/launcher-windows.go
@@ -3,16 +3,4 @@
 
 package launchlib
 
-import (
-	"os/exec"
-
-	"golang.org/x/sys/windows"
-)
-
 const javaExecutablePath = "bin/java.exe"
-
-func setSysProcAttr(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &windows.SysProcAttr{
-		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
-	}
-}

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -187,7 +187,7 @@ func verifyPathIsSafeForExec(execPath string) (string, error) {
 	} else if _, statErr := os.Stat(execPath); statErr != nil {
 		return "", statErr
 	}
-
+	fmt.Printf("Using exec path: %q ", execPath)
 	return execPath, nil
 }
 
@@ -241,7 +241,7 @@ func absolutizeClasspathEntries(workingDir string, relativeClasspathEntries []st
 }
 
 func joinClasspathEntries(classpathEntries []string) string {
-	return strings.Join(classpathEntries, ":")
+	return strings.Join(classpathEntries, string(os.PathListSeparator))
 }
 
 func createCmd(executable string, args []string, customEnv map[string]string) (*exec.Cmd, error) {

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -187,7 +187,6 @@ func verifyPathIsSafeForExec(execPath string) (string, error) {
 	} else if _, statErr := os.Stat(execPath); statErr != nil {
 		return "", statErr
 	}
-	fmt.Printf("Using exec path: %q ", execPath)
 	return execPath, nil
 }
 

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -123,7 +123,7 @@ func compileCmdFromConfig(
 
 			jvmOpts := createJvmOpts(combinedJvmOpts, customConfig, logger)
 
-			executable, executableErr = verifyPathIsSafeForExec(path.Join(javaHome, "/bin/java"))
+			executable, executableErr = verifyPathIsSafeForExec(path.Join(javaHome, javaExecutablePath))
 			if executableErr != nil {
 				return nil, executableErr
 			}

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -20,7 +20,7 @@ import (
 	"maps"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"slices"
@@ -123,7 +123,7 @@ func compileCmdFromConfig(
 
 			jvmOpts := createJvmOpts(combinedJvmOpts, customConfig, logger)
 
-			executable, executableErr = verifyPathIsSafeForExec(path.Join(javaHome, javaExecutablePath))
+			executable, executableErr = verifyPathIsSafeForExec(filepath.Join(javaHome, javaExecutablePath))
 			if executableErr != nil {
 				return nil, executableErr
 			}
@@ -234,7 +234,7 @@ func getWorkingDir() string {
 func absolutizeClasspathEntries(workingDir string, relativeClasspathEntries []string) []string {
 	absoluteClasspathEntries := make([]string, len(relativeClasspathEntries))
 	for i, entry := range relativeClasspathEntries {
-		absoluteClasspathEntries[i] = path.Join(workingDir, entry)
+		absoluteClasspathEntries[i] = filepath.Join(workingDir, entry)
 	}
 	return absoluteClasspathEntries
 }

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -30,10 +30,8 @@ import (
 )
 
 const (
-	TemplateDelimsOpen  = "{{"
-	TemplateDelimsClose = "}}"
-	// ExecPathBlackListRegex matches characters disallowed in paths we allow to be passed to exec()
-	ExecPathBlackListRegex           = `[^\w.\/_\-]`
+	TemplateDelimsOpen               = "{{"
+	TemplateDelimsClose              = "}}"
 	BytesInMebibyte                  = 1048576
 	defaultNativeImageExecutablePath = "service/bin/native-executable"
 )
@@ -178,9 +176,9 @@ func MkDirs(dirs []string, stdout io.Writer) error {
 	return nil
 }
 
-// Returns true iff the given path is safe to be passed to exec(): must not contain funky characters and be a valid file
+// Returns true iff the given path is safe to be passed as the executable: must not contain funky characters and be a valid file
 func verifyPathIsSafeForExec(execPath string) (string, error) {
-	if unsafe, err := regexp.MatchString(ExecPathBlackListRegex, execPath); err != nil {
+	if unsafe, err := regexp.MatchString(pathBlackListRegex, execPath); err != nil {
 		return "", err
 	} else if unsafe {
 		return "", fmt.Errorf("Unsafe execution path: %q ", execPath)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Go-init had no support for running on windows

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Adds windows support for go-init by:
- Makes the java binary path dependent on the target OS
- Adds a windows implementation of the `isProcRunning` function
- Adds a windows implementation for `stopService`

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

- The windows versions does not support graceful shutdown