### PR TITLE
enable single node ZGC testing

### DIFF
--- a/launchlib/config.go
+++ b/launchlib/config.go
@@ -96,6 +96,9 @@ type ExperimentalLauncherConfig struct {
 	// Deprecated: use the top-level allowHeapShrink field on CustomLauncherConfig instead. This field is retained
 	// for backwards compatibility with existing overrides that set it under experimental.
 	AllowHeapShrink bool `yaml:"allowHeapShrink,omitempty"`
+	// ZGCCanaryHostnameSuffix replaces the SLS Packaging GC profile options on the host whose name has the
+	// configured suffix.
+	ZGCCanaryHostnameSuffix string `yaml:"zgcCanaryHostnameSuffix,omitempty"`
 }
 
 type PrimaryCustomLauncherConfig struct {

--- a/launchlib/config_test.go
+++ b/launchlib/config_test.go
@@ -465,6 +465,28 @@ env:
 				},
 			},
 		},
+		{
+			name: "ZGC canary is parsed",
+			data: `
+configType: java
+configVersion: 1
+experimental:
+  zgcCanaryHostnameSuffix: "-1-0"
+`,
+			want: PrimaryCustomLauncherConfig{
+				VersionedConfig: VersionedConfig{
+					Version: 1,
+				},
+				CustomLauncherConfig: CustomLauncherConfig{
+					TypedConfig: TypedConfig{
+						Type: "java",
+					},
+					Experimental: ExperimentalLauncherConfig{
+						ZGCCanaryHostnameSuffix: "-1-0",
+					},
+				},
+			},
+		},
 	} {
 		got, _ := parseCustomConfig([]byte(currCase.data))
 		assert.Equal(t, currCase.want, got, "Case %d: %s", i, currCase.name)

--- a/launchlib/gc.go
+++ b/launchlib/gc.go
@@ -46,12 +46,14 @@ func applyZGCCanaryJvmOpts(
 }
 
 func useSLSPackagingZGCProfile(jvmOpts []string) []string {
-	filtered := make([]string, 0, len(jvmOpts)+3)
+	filtered := make([]string, 0, len(jvmOpts)+4)
 	for _, opt := range jvmOpts {
 		if !isReplacedGCProfileJvmOpt(opt) {
 			filtered = append(filtered, opt)
 		}
 	}
+
+	filtered = append(filtered, "-XX:-UseG1GC")
 
 	// Keep these aligned with the JDK 21+ response-time profile in sls-packaging's GcProfile.ResponseTime:
 	// https://github.com/palantir/sls-packaging/blob/develop/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java

--- a/launchlib/gc.go
+++ b/launchlib/gc.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package launchlib
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+func applyZGCCanaryJvmOpts(
+	combinedJvmOpts []string,
+	hostnameSuffix string,
+	hostnameFunc func() (string, error),
+	logger io.Writer,
+) []string {
+	if hostnameSuffix == "" {
+		return combinedJvmOpts
+	}
+
+	hostname, err := hostnameFunc()
+	if err != nil {
+		_, _ = fmt.Fprintf(logger, "Failed to resolve hostname for experimental ZGC canary; retaining configured JVM options: %v\n", err)
+		return combinedJvmOpts
+	}
+	if !strings.HasSuffix(hostname, hostnameSuffix) {
+		_, _ = fmt.Fprintf(logger, "ZGC canary hostname %q does not match suffix %q; retaining configured GC profile\n", hostname, hostnameSuffix)
+		return combinedJvmOpts
+	}
+
+	_, _ = fmt.Fprintf(logger, "ZGC canary hostname %q matches suffix %q; selecting SLS Packaging response-time profile\n",
+		hostname, hostnameSuffix)
+	return useSLSPackagingZGCProfile(combinedJvmOpts)
+}
+
+func useSLSPackagingZGCProfile(jvmOpts []string) []string {
+	filtered := make([]string, 0, len(jvmOpts)+3)
+	for _, opt := range jvmOpts {
+		if !isReplacedGCProfileJvmOpt(opt) {
+			filtered = append(filtered, opt)
+		}
+	}
+
+	// Keep these aligned with the JDK 21+ response-time profile in sls-packaging's GcProfile.ResponseTime:
+	// https://github.com/palantir/sls-packaging/blob/develop/gradle-sls-packaging/src/main/java/com/palantir/gradle/dist/service/gc/GcProfile.java
+	// ZGenerational is ignored by JDK 24+, but retained while sls-packaging emits it.
+	return append(filtered,
+		"-XX:+UseZGC",
+		"-XX:+ZGenerational",
+		"-XX:+ExplicitGCInvokesConcurrent")
+}
+
+func isReplacedGCProfileJvmOpt(opt string) bool {
+	if strings.HasPrefix(opt, "-XX:MaxGCPauseMillis=") {
+		return true
+	}
+
+	const xxBooleanOptionPrefix = "-XX:"
+	if !strings.HasPrefix(opt, xxBooleanOptionPrefix) || len(opt) <= len(xxBooleanOptionPrefix) {
+		return false
+	}
+	if opt[len(xxBooleanOptionPrefix)] != '+' && opt[len(xxBooleanOptionPrefix)] != '-' {
+		return false
+	}
+	option := opt[len(xxBooleanOptionPrefix)+1:]
+	switch option {
+	case "UseSerialGC",
+		"UseParallelGC",
+		"UseParallelOldGC",
+		"UseParNewGC",
+		"UseConcMarkSweepGC",
+		"UseG1GC",
+		"UseZGC",
+		"UseShenandoahGC",
+		"UseEpsilonGC",
+		"UseNUMA",
+		"ZGenerational",
+		"ExplicitGCInvokesConcurrent":
+		return true
+	default:
+		return false
+	}
+}

--- a/launchlib/gc_test.go
+++ b/launchlib/gc_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package launchlib
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyZGCCanaryJvmOpts(t *testing.T) {
+	configuredOpts := []string{
+		"-XX:+UseG1GC",
+		"-XX:+UseNUMA",
+		"-XX:MaxGCPauseMillis=500",
+		"-XX:-UseZGC",
+		"-XX:-ZGenerational",
+		"-XX:-ExplicitGCInvokesConcurrent",
+		"-Xmx4g",
+		"-Dfoo=bar",
+	}
+	zgcOpts := []string{
+		"-Xmx4g",
+		"-Dfoo=bar",
+		"-XX:+UseZGC",
+		"-XX:+ZGenerational",
+		"-XX:+ExplicitGCInvokesConcurrent",
+	}
+
+	for _, tc := range []struct {
+		name        string
+		hostname    string
+		hostnameErr error
+		want        []string
+		wantLog     string
+	}{
+		{
+			name:     "matching hostname uses SLS Packaging ZGC profile",
+			hostname: "services-mojito-foundry-multipass-1-0",
+			want:     zgcOpts,
+			wantLog:  `hostname "services-mojito-foundry-multipass-1-0" matches suffix "-1-0"`,
+		},
+		{
+			name:     "non-matching hostname preserves configured options",
+			hostname: "services-mojito-foundry-multipass-0-0",
+			want:     configuredOpts,
+			wantLog:  `hostname "services-mojito-foundry-multipass-0-0" does not match suffix "-1-0"`,
+		},
+		{
+			name:        "hostname failure preserves configured options",
+			hostnameErr: errors.New("hostname unavailable"),
+			want:        configuredOpts,
+			wantLog:     "retaining configured JVM options: hostname unavailable",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			got := applyZGCCanaryJvmOpts(
+				configuredOpts,
+				"-1-0",
+				func() (string, error) { return tc.hostname, tc.hostnameErr },
+				&logs,
+			)
+
+			assert.Equal(t, tc.want, got)
+			assert.Contains(t, logs.String(), tc.wantLog)
+		})
+	}
+}
+
+func TestUseSLSPackagingZGCProfileRemovesOtherCollectorSelectors(t *testing.T) {
+	got := useSLSPackagingZGCProfile([]string{
+		"-XX:+UseSerialGC",
+		"-XX:-UseParallelGC",
+		"-XX:+UseParallelOldGC",
+		"-XX:+UseParNewGC",
+		"-XX:+UseConcMarkSweepGC",
+		"-XX:+UseG1GC",
+		"-XX:+UseZGC",
+		"-XX:+UseShenandoahGC",
+		"-XX:+UseEpsilonGC",
+	})
+
+	assert.Equal(t, []string{
+		"-XX:+UseZGC",
+		"-XX:+ZGenerational",
+		"-XX:+ExplicitGCInvokesConcurrent",
+	}, got)
+}

--- a/launchlib/gc_test.go
+++ b/launchlib/gc_test.go
@@ -36,6 +36,7 @@ func TestApplyZGCCanaryJvmOpts(t *testing.T) {
 	zgcOpts := []string{
 		"-Xmx4g",
 		"-Dfoo=bar",
+		"-XX:-UseG1GC",
 		"-XX:+UseZGC",
 		"-XX:+ZGenerational",
 		"-XX:+ExplicitGCInvokesConcurrent",
@@ -96,6 +97,7 @@ func TestUseSLSPackagingZGCProfileRemovesOtherCollectorSelectors(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{
+		"-XX:-UseG1GC",
 		"-XX:+UseZGC",
 		"-XX:+ZGenerational",
 		"-XX:+ExplicitGCInvokesConcurrent",

--- a/launchlib/launcher.go
+++ b/launchlib/launcher.go
@@ -119,6 +119,8 @@ func compileCmdFromConfig(
 				staticConfig.JavaConfig.Classpath))
 			_, _ = fmt.Fprintf(logger, "Classpath: %s\n", classpath)
 
+			combinedJvmOpts = applyZGCCanaryJvmOpts(
+				combinedJvmOpts, customConfig.Experimental.ZGCCanaryHostnameSuffix, os.Hostname, logger)
 			jvmOpts := createJvmOpts(combinedJvmOpts, customConfig, logger)
 
 			executable, executableErr = verifyPathIsSafeForExec(filepath.Join(javaHome, javaExecutablePath))


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
we cannot test ZGC on a single node, it is all-or-nothing. Instead, we could allow a single node to use ZGC, and compare performance more directly.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

